### PR TITLE
バックエンドに「ブログ作成」用apiを追加(+バックエンドの単体テスト) & フロントに「ブログ作成用画面」を追加(+フロントエンドのmockedテスト)

### DIFF
--- a/backend/api/blog/serializers.py
+++ b/backend/api/blog/serializers.py
@@ -3,25 +3,28 @@ from api.models.blogs import Blog
 
 
 class BlogRequestSerializer(serializers.Serializer):
+    # Blog一覧APIへのリクエストを受け付けるシリアライザ
     # このシリアライザで受け付けるパラメータ(例えばtitleで絞るため、?title=abcなどとブラウザに入力できるようにする)
-    title = serializers.CharField(required=False, max_length=255)
+    title = serializers.CharField(required=False, max_length=255,label="タイトル",
+        help_text="検索による絞り込み用にタイトルを入力してください")
     size = serializers.IntegerField(required=False, min_value=1, max_value=100)
     page = serializers.IntegerField(required=False)
     sort = serializers.CharField(required=False)
     keyword = serializers.CharField(required=False, max_length=255)
-    def is_valid(self, raise_exception=False):
-        # 未定義のパラメータがあればエラーにする
+
+    def validate(self, attrs):
+        # 未定義のパラメータ(unknown_keys)があればエラーにする
         # 例えば、?titlea=abcなどとブラウザにいれてこのシリアライザを使う場合、エラーになるようにするため、is_validをオーバーライド
         # もしこのis_validのオーバーライドがないと、適当なパラメータで検索をかけても動作してしまう。
+        print("---attrs", attrs)
+        print("---self.initial_data", self.initial_data)
         unknown_keys = set(self.initial_data.keys()) - set(self.fields.keys())
         if unknown_keys:
-            # シリアライザとして定義していないパラメータがクエリパラメータとして仕込まれていたなら、Falseを返す　= is_valid()の結果がfalseになる
-            self._errors = {key: ["Unexpected parameter."] for key in unknown_keys}
-            # if raise_exception:
-            #     raise serializers.ValidationError(self._errors)
-            return False
-
-        return super().is_valid(raise_exception=raise_exception)
+            # シリアライザとして定義していないパラメータがクエリパラメータとして仕込まれていた(unknown_keysがある)なら、serializers.ValidationErrorを返す
+            raise serializers.ValidationError({
+                key: ["Unexpected parameter."] for key in unknown_keys
+            })
+        return attrs
     def validate_sort(self, value):
         # このメソッドはis_valid実行時にともに実行される
         # 明示的に実行させる必要はなく、このシリアライザに渡された辞書内のキー名がsortになっているもの値についてバリデーションチェックを実施する
@@ -32,6 +35,7 @@ class BlogRequestSerializer(serializers.Serializer):
         return value
 
 class BlogResponseSerializer(serializers.ModelSerializer):
+    # Blogモデルのレコードを返すためのシリアライザ
     class Meta:
         # Blogモデルのレコードを返すことを意味し、つけるフィールドを指定
         model = Blog
@@ -44,3 +48,31 @@ class BlogResponseSerializer(serializers.ModelSerializer):
 # 1. レスポンス用シリアライザの中で、to_representation()やSerializerMethodField()を使いだした時
 # 2. レスポンス用シリアライザの中で、外部APIや複雑なロジックで値の加工をしだした場合
 # 3. レスポンス用シリアライザで、値の形式変換をしだしたとき (日時のフォーマットを、yyyyMMddhhmmから変更をシリアライザでやりだした時)とか
+
+class BlogCreateRequestSerializer(serializers.Serializer):
+    title = serializers.CharField(required=True, max_length=200,label="タイトル",
+        help_text="検索による絞り込み用にタイトルを入力してください")
+    contents_text = serializers.CharField(required=True,)
+    class Meta:
+        model = Blog
+        # このシリアライザで受けるキーを限定。「これら以外がくるとエラーになるようにする」のがvalidateメソッドの話。
+        fields = ("title", "contents_text")
+
+    def validate(self, attrs):
+        # リクエストの全体データをチェック
+        request_data_keys = set(self.initial_data.keys())
+        allowed_keys = set(self.fields.keys())
+
+        # 許可されていないキー(=フィールド)が含まれているか
+        extra_keys = request_data_keys - allowed_keys
+        if extra_keys:
+            raise serializers.ValidationError(f"不正なフィールドが含まれています: {', '.join(extra_keys)}")
+
+        return attrs
+
+#----
+# リクエストシリアライザ内のis_validメソッドのオーバーライドをやめて、validateメソッドのオーバーライドにした理由
+# メソッド	主な用途	呼び出されるタイミング	適した処理
+# is_valid()	全体のバリデーション処理を起動	呼び出し時に1度だけ	通常は上書きしない
+# validate()	全フィールドを検査（cross-field含む）	is_valid() の中で呼ばれる	今回のような全体検査
+# validate_<field>()	単一フィールドの検証	各フィールド処理時	個別の条件検証

--- a/backend/api/blog/views.py
+++ b/backend/api/blog/views.py
@@ -93,7 +93,10 @@ class BlogViewSet(viewsets.GenericViewSet):
 
         serializer = BlogResponseSerializer(blog)
         return Response(serializer.data)
-    
+    # def create(self, request, *args, **kwargs):
+    # # このメソッドは意図的に500エラーを発生させるために使っていました。今後は使わない
+    #     raise Exception("意図的な500 Internal Server Error")
+
     def create(self, request, *args, **kwargs):
         # TODO: 今のところブログ作成機能はview、serializer含めかなり記述量がすくない。
         # しかし、①ログインしたユーザーのみ作成許可や、②同じタイトルをつけることができないようにする場合

--- a/backend/api/tests/blogs/test_create.py
+++ b/backend/api/tests/blogs/test_create.py
@@ -1,0 +1,100 @@
+import pytest
+from rest_framework.test import APIClient
+from rest_framework import status
+from api.models.blogs import Blog
+
+# クラス内の各テストケースで使うことになるAPIClientの準備
+# ただし、テストケースメソッドにapi_clientを引数にいれたら、conftest.pyのフィクスチャを使って同じことができる
+client = APIClient()
+
+@pytest.fixture
+def data_for_blogcreate():
+    # ブログ作成APIのテスト用のデータを返す
+    return {
+        "title": "テストタイトル",
+        "contents_text": "テスト本文",
+    }
+
+
+
+@pytest.mark.django_db
+class TestBlogCreateAPI:
+    #このクラス内のテストケースメソッドに引数にdbを入れなくても、@pytest.mark.django_dbをつけることで、テストケースメソッド内でテスト用DBを使えるようになる
+    # api_clientは、conftest.pyで@pytest.fixtureで定義したフィクスチャ
+    # data_for_blogcreateは、同じこのファイルで定義のフィクスチャ (← あまり意味はないが説明のため)
+    def test_create_blog_success(self, api_client, data_for_blogcreate):
+        """正常系"""
+        
+        # フィクスチャを使う前は以下のように、ブログ作成に必要なパラメータを「テストケース内で」準備していた
+        # data = {
+        #     "title": "テストタイトル",
+        #     "contents_text": "テスト本文",
+        # }
+        # フィクスチャを使わない場合以下のようにAPIClientをインスタンスをこのテストケースで作成してpostリクエスト=blog作成していた。
+        # response = client.post("/api/v1/blogs/", data, format="json")
+        
+        # 現在は以下のように、フィクスチャからのAPIClientとパラメータを使ってpost=ブログ作成している。
+        response = api_client.post("/api/v1/blogs/", data_for_blogcreate, format="json")
+        # ブログ作成時のレスポンスのステータスコードを確認(正常のはず)
+        assert response.status_code == status.HTTP_201_CREATED
+        
+        # レスポンスには、作成時に渡したパラメータが含まれているはず(フィクスチャ未使用版と使用版)
+        # assert response.data["title"] == data["title"]
+        # assert response.data["contents_text"] == data["contents_text"]
+        assert response.data["title"] == data_for_blogcreate["title"]
+        assert response.data["contents_text"] == data_for_blogcreate["contents_text"]
+        # 作成されたブログは1件だけのはずなので確認する
+        assert Blog.objects.count() == 1
+
+    def test_create_blog_missing_title(self):
+        """エラー系 ブログ作成時に、本文だけ値があるとエラーになること"""
+        data = {
+            "contents_text": "本文だけ",
+        }
+        response = client.post("/api/v1/blogs/", data, format="json")
+        # 作成できなかったはずなので、ステータスを確認する(エラーが返ってくるはず)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # ブログを作成できなかった時のレスポンスには、「titleがパラメータになかったから」が含まれているか
+        assert "title" in response.data
+
+    def test_create_blog_missing_contents(self):
+        """エラー系 ブログ作成時に、ブログ作成時に、タイトルだけ値があるとエラーになること"""
+        data = {
+            "title": "タイトルだけ",
+        }
+        response = client.post("/api/v1/blogs/", data, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "contents_text" in response.data
+
+    def test_create_blog_with_unknown_field(self):
+        """エラー系 ブログ作成時に、シリアライザが定義していないフィールドへの入力があればエラーになること"""
+        
+        data = {
+            "title": "不正テストのokなタイトル",
+            "contents_text": "OKな本文",
+            "extra": "これは余計なキー",    # ←ブログ作成に使うシリアライザはextraというキーを想定していない
+        }
+        response = client.post("/api/v1/blogs/", data, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # ブログ作成リクエスト用シリアライザに、余計なキー(フィールド)があった状態でpostリクエストしたらエラー
+        # そのエラーに終わった時のレスポンスにも、エラーの理由として「余計なキーがあったから」を意味するnon_field_errorsが入っているか
+        assert "non_field_errors" in response.data
+        # レスポンスのnon_field_errorsの内容を確認する
+        assert response.data["non_field_errors"][0] == "不正なフィールドが含まれています: extra"
+    def test_create_blog_with_invalid_type(self):
+        """エラー系 ブログ作成時に、文字列へ変換できない値をapiへ渡した場合エラーになることを確認する"""
+        data = {
+            "title": False,  # 本来はstrまたはstrにキャストできるものでないと受け付けられない
+            "contents_text": True,  # 本来はstrまたはstrにキャストできるものでないと受け付けられない
+        }
+        response = client.post("/api/v1/blogs/", data, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # ブログを作成できなかった時のレスポンスには、「titleと、contesnts_textそれぞれに問題があったから」となっているかどうか
+        assert "title" in response.data
+        assert "contents_text" in response.data
+
+# setup_methodやsetup_classを使って個々のテストを実行する前に前処理をすることもできるが、ログインができないと意味が薄いので
+# 今はpytest.fixureのみで十分

--- a/frontend/src/pages/BlogCreate.vue
+++ b/frontend/src/pages/BlogCreate.vue
@@ -1,0 +1,82 @@
+<!-- BlogCreate.vue（簡易例） -->
+<template>
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-2xl font-bold mb-4">ブログ作成</h1>
+    <form @submit.prevent="submitBlog" class="">
+        <!-- formタグの記述内容は https://qiita.com/koinunopochi/items/cdff29b65a5f26224e95 -->
+        <!-- https://qiita.com/shizen-shin/items/33845020453b0af6ebde -->
+        <h2 class="text-xl font-semibold">ブログタイトル</h2>
+        <!-- ↓のinputに入れられた文字は v-modelに指定した変数に入る -->
+        <input data-testid="blogcreate-input-title" class=" mb-4 p-4 rounded-xl shadow bg-white border w-full" v-model="title" placeholder="タイトル" required />
+        <h2 class="text-xl font-semibold">本文</h2>
+        <!-- ↓のtextareaに入れられた文字は v-modelに指定した変数に入る -->
+        <textarea data-testid="blogcreate-textarea-contents-text" class="mb-2 p-4 rounded-xl shadow bg-white border w-full" v-model="contentsText" placeholder="本文" required />
+        
+        <div class="mt-6 mx-4 flex justify-between items-center space-x-4">
+            <button
+            type="button"
+            class="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+            @click="backBlogListPage"
+            data-testid="blogcreate-back-btn"
+            >
+            <!-- 戻るボタン -->
+            戻る
+            </button>
+
+            <button type="submit" data-testid="blogcreate-submit-btn" class="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300">
+            <!-- 作成ボタン このボタンが押されることでsubmitイベントが発火 = formタグは「submitイベント発火時はsubmitBlog実施」状態になっているのでバックエンドへPOSTリクエストされる -->
+                作成
+            </button>
+        </div>
+        
+    </form>
+    <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+</div>
+</template>
+  
+
+<script setup lang="ts">
+import { ref } from "vue"
+import { useRouter } from "vue-router"
+
+const title = ref("")
+const contentsText = ref("")
+const errorMessage = ref("")
+const router = useRouter()
+
+const submitBlog = async () => {
+    try {
+        // バックエンドへPOSTリクエスト 第2引数がオブジェクトで、バックエンドへ渡す内容
+        // オブジェクトのbodyについては、「refで定義した変数 = フォームのinputやtextareaの記述内容」からオブジェクトを作成 → 「JSON.stringifyで文字列化した結果」がbodyの値になっている
+        const response = await fetch("http://localhost:8000/api/v1/blogs/", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                title: title.value,
+                contents_text: contentsText.value,
+            }),
+        })
+
+        if (!response.ok) {
+            // 
+            const errorData = await response.json()
+            errorMessage.value = errorData?.detail || "作成に失敗しました"
+            return
+        }
+
+        // 成功時は一覧ページにリダイレクト（必要に応じて）
+        router.push("/blogs/")
+    } catch (error) {
+        errorMessage.value = "ネットワークエラーが発生しました"
+    }
+}
+
+const backBlogListPage = ()=>{
+  console.log("--戻るボタン--")
+  router.push('/blogs')  // 一覧画面に戻る
+};
+
+</script>
+

--- a/frontend/src/pages/BlogCreate.vue
+++ b/frontend/src/pages/BlogCreate.vue
@@ -32,7 +32,7 @@
         </div>
         
     </form>
-    <!-- <p v-if="errorMessage" class="error">{{ errorMessage }}</p> -->
+    <p v-if="errorMessage" data-testid="blogcreate-backend-error-message" class="error">{{ errorMessage }}</p>
 </div>
 </template>
   
@@ -66,7 +66,7 @@ const { handleSubmit, errors :form_errors } = useForm({
 // {value: title}のtitleは、v-modelで使用できるようになる。useField('title')の方はschemaｍのyup.objectに入れたオブジェクトのことを指す
 const { value: title} = useField('title')
 const { value: contents_text} = useField('contents_text')
-
+// useFieldで定義しているので、v-modelで双方バインディングする変数は作成しなくていい。
 // const title = ref("")
 // const contentsText = ref("")
 const errorMessage = ref("")

--- a/frontend/src/pages/BlogCreate.vue
+++ b/frontend/src/pages/BlogCreate.vue
@@ -91,9 +91,15 @@ const submitBlog = handleSubmit (async (form_values) => {
         })
 
         if (!response.ok) {
-            const errorData = await response.json()
-            errorMessage.value = errorData?.detail || "作成に失敗しました"
-            return
+            const errorData = await response.json();
+            
+            if (errorData.detail) {
+                errorMessage.value = errorData.detail;
+            } else {
+                // 複数フィールドのバリデーションエラーをまとめて表示する例（必要に応じて整形）
+                errorMessage.value = Object.values(errorData).flat().join("／");
+            }
+            return;
         }
 
         // 成功時は一覧ページにリダイレクト（必要に応じて）

--- a/frontend/src/pages/BlogDetail.vue
+++ b/frontend/src/pages/BlogDetail.vue
@@ -1,11 +1,11 @@
 <!-- src/pages/BlogDetail.vue -->
 <template>
-  <div class="p-4">
+  <div class="container mx-auto px-4 py-8">
     <h1 class="text-2xl font-bold mb-4">ブログ詳細</h1>
     <div v-if="blog">
-      <h2 class="text-xl font-semibold" data-testid="blogretrive-blog-title">{{ blog.title }}</h2>
+      <h2 class="mb-2 p-4 rounded-xl shadow bg-white bordertext-xl font-semibold w-full" data-testid="blogretrive-blog-title">{{ blog.title }}</h2>
       <p class="text-gray-600 text-sm mb-2">投稿日: {{ blog.created }}</p>
-      <p  data-testid="blogretrive-blog-contents-text">{{ blog.contents_text }}</p>
+      <p  data-testid="blogretrive-blog-contents-text" class ="w-full p-4 rounded-xl">{{ blog.contents_text }}</p>
     </div>
     <div v-else>
       ロード中...

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -5,13 +5,18 @@ const routes = [
   {
     path: '/blogs',
     name: 'BlogList',
-    component: () => import('@/pages/BlogList.vue'), // 後ほど作成
+    component: () => import('@/pages/BlogList.vue'),
   },
   {
     path: '/blogs/:id',
     name: 'BlogDetail',
-    component: () => import('@/pages/BlogDetail.vue'), // 後ほど作成
+    component: () => import('@/pages/BlogDetail.vue'), 
   },
+  {
+    path: "/blogs/create",
+    name: "BlogCreate",
+    component: () => import('@/pages/BlogCreate.vue'),
+  }
 ]
 // main.tsでよみこむrouter(はcreateRouterオブジェクト)
 const router = createRouter({

--- a/playwright-mock/mocked_tests/blog/test_create.py
+++ b/playwright-mock/mocked_tests/blog/test_create.py
@@ -1,21 +1,44 @@
 import pytest
 from playwright.sync_api import Page, Route, Request, expect
 
-@pytest.mark.parametrize("route_status", [201])
-def test_create_blog_success(page: Page, route_status):
-    # モック: POST /api/v1/blogs/ に対して成功レスポンスを返す
-    def handle_blog_create(route: Route, request: Request):
-        assert request.method == "POST"
-        payload = request.post_data_json
-        assert "title" in payload
-        assert "contents_text" in payload
+#---バックエンドのモック---
+# 正常系なブログ作成用モック
+def handle_blog_create_201(route: Route, request: Request):
+    if request.method == "POST" and "/api/v1/blogs/" in request.url:
         route.fulfill(
-            status=route_status,
+            status=201,
             content_type="application/json",
             body='{"id": 1, "title": "モックタイトル", "contents_text": "モック本文"}'
         )
-    
-    page.route("**/api/v1/blogs/", handle_blog_create)
+    else:
+        route.continue_()
+
+# バリデーションエラー: 400)
+def handle_blog_create_400(route: Route, request: Request):
+    if request.method == "POST" and "/api/v1/blogs/" in request.url:
+        route.fulfill(
+            status=400,
+            content_type="application/json",
+            body='{"detail": "エラーが発生しました"}'
+        )
+    else:
+        route.continue_()
+# サーバーエラー: 500
+def handle_blog_create_500(route: Route, request: Request):
+    if request.method == "POST" and "/api/v1/blogs/" in request.url:
+        route.fulfill(
+            status=500,
+            content_type="application/json",
+            body='{"detail": "Internal Server Error"}'
+        )
+    else:
+        route.continue_()
+
+#---テストケース---
+def test_create_blog_success(page: Page):
+    """正常系"""
+    # ブログ作成api(のモック)を準備: POST /api/v1/blogs/ に対して成功レスポンスを返す
+    page.route("**/api/v1/blogs/", handle_blog_create_201)
 
     # フロントエンドの作成画面へ遷移
     page.goto("http://frontend:5173/blogs/create")
@@ -31,7 +54,11 @@ def test_create_blog_success(page: Page, route_status):
     expect(page).to_have_url("http://frontend:5173/blogs")
 
 
+
 def test_create_blog_with_empty_fields(page: Page):
+    """バリデーションエラー タイトル、本文ともに入力しない場合"""
+    # このテストケースではブログ作成apiのモックをしてもしなくても結果が変わらないが一応準備
+    page.route("**/api/v1/blogs/", handle_blog_create_201)
     page.goto("http://frontend:5173/blogs/create")
 
     # 何も入力せずに送信ボタンをクリック ← ブログ作成はされないはず
@@ -47,6 +74,9 @@ def test_create_blog_with_empty_fields(page: Page):
 
 
 def test_create_blog_with_title_too_long(page: Page):
+    """バリデーションエラー タイトルの文字列が長すぎる場合"""
+    # このテストケースではブログ作成apiのモックをしてもしなくても結果が変わらないが一応準備
+    page.route("**/api/v1/blogs/", handle_blog_create_201)
     page.goto("http://frontend:5173/blogs/create")
 
     # 201文字のタイトルを入力
@@ -62,6 +92,81 @@ def test_create_blog_with_title_too_long(page: Page):
     # バリデーションエラーになるはずなので、メッセージがでているかの検証
     expect(page.get_by_test_id("blogcreate-input-title-error")).to_be_visible()
     # エラーメッセージの内容を検証
-    expect(page.get_by_text("タイトルは200文字以内で入力してください")).to_be_visible()
+    expect(page.get_by_test_id("blogcreate-input-title-error")).to_have_text("タイトルは200文字以内で入力してください")
     # 本文の入力欄についてのバリデーションエラーはでていないはず
     expect(page.get_by_test_id("bblogcreate-textarea-contents-text-error")).not_to_be_visible()
+
+
+
+def test_blog_create_request_payload(page: Page):
+    """バリデーションエラー タイトルの文字列が長すぎる場合"""
+    # このテストケースではブログ作成apiのモックをしてもしなくても結果が変わらないが一応準備
+    page.route("**/api/v1/blogs/", handle_blog_create_201)
+    page.goto("http://frontend:5173/blogs/create")
+
+    # フィールドに値を入力
+    page.get_by_test_id("blogcreate-input-title").fill("テストタイトル")
+    page.get_by_test_id("blogcreate-textarea-contents-text").fill("テスト本文")
+
+    # POST リクエストを実施する
+    with page.expect_request("**/api/v1/blogs/") as intercepted_request:
+        page.get_by_test_id("blogcreate-submit-btn").click()
+
+    request_obj = intercepted_request.value
+    # POSTリクエストが行われた ことを確認
+    assert request_obj.method == "POST"
+
+    # リクエストのボディの内容を検証
+    assert request_obj.post_data_json == {
+        "title": "テストタイトル",
+        "contents_text": "テスト本文"
+    }
+
+@pytest.mark.parametrize("handler,error_message,expect_backend_status", [
+    (handle_blog_create_201, "", 201),
+    (handle_blog_create_400, "エラーが発生しました", 400),
+    (handle_blog_create_500, "Internal Server Error", 500),
+])
+def test_blog_create_response_data(page: Page, handler, error_message, expect_backend_status):
+    """バックエンドからのレスポンスを検証し、その内容からフロントエンドの挙動を確認する"""
+    page.route("**/api/v1/blogs/", handler)
+
+    page.goto("http://frontend:5173/blogs/create")
+
+    # 入力
+    page.get_by_test_id("blogcreate-input-title").fill("テストタイトル")
+    page.get_by_test_id("blogcreate-textarea-contents-text").fill("テスト本文")
+
+    # ブログ作成apiへpostリクエスト → その結果のレスポンスをキャッチ
+    with page.expect_response("**/api/v1/blogs/") as response_info:
+        # 送信ボタンをクリック
+        page.get_by_test_id("blogcreate-submit-btn").click()
+    
+    # レスポンスオブジェクト取得
+    response = response_info.value
+    # ステータスコード確認
+    assert response.status == expect_backend_status
+    # JSONレスポンスの中身確認
+    data = response.json()
+    if expect_backend_status == 201:
+        # 成功時のレスポンス確認
+        assert data["id"] == 1
+        assert data["title"] == "モックタイトル"
+        assert data["contents_text"] == "モック本文"
+    elif expect_backend_status == 400:
+        # エラーメッセージが表示されるか確認
+        expect(page.get_by_test_id("blogcreate-backend-error-message")).to_be_visible()
+        # 400エラー時のレスポンス確認
+        assert data["detail"] == "エラーが発生しました"
+        # エラーメッセージの内容を確認
+        expect(page.get_by_test_id("blogcreate-backend-error-message")).to_have_text(error_message)
+    elif expect_backend_status == 500:
+        # エラーメッセージが表示されるか確認
+        expect(page.get_by_test_id("blogcreate-backend-error-message")).to_be_visible()
+        # サーバーエラー=500エラー時のレスポンス確認
+        assert data["detail"] == "Internal Server Error"
+        # エラーメッセージの内容を確認
+        expect(page.get_by_test_id("blogcreate-backend-error-message")).to_have_text(error_message)        
+
+
+

--- a/playwright-mock/mocked_tests/blog/test_create.py
+++ b/playwright-mock/mocked_tests/blog/test_create.py
@@ -24,8 +24,44 @@ def test_create_blog_success(page: Page, route_status):
     page.get_by_test_id("blogcreate-input-title").fill("モックタイトル")
     page.get_by_test_id("blogcreate-textarea-contents-text").fill("モック本文")
 
-    # 送信ボタンをクリック
+    # 送信ボタンをクリック ← ブログが作成されたはず
     page.get_by_test_id("blogcreate-back-btn").click()
 
-    # 成功した場合の挙動を検証（例：トップページに戻る）
+    # 成功した場合の挙動を検証 = ブログ一覧ページに戻っているはず
     expect(page).to_have_url("http://frontend:5173/blogs")
+
+
+def test_create_blog_with_empty_fields(page: Page):
+    page.goto("http://frontend:5173/blogs/create")
+
+    # 何も入力せずに送信ボタンをクリック ← ブログ作成はされないはず
+    page.get_by_test_id("blogcreate-submit-btn").click()
+
+    # バリデーションエラーになるはずなので、メッセージがでているかの検証
+    expect(page.get_by_test_id("blogcreate-input-title-error")).to_be_visible()
+    expect(page.get_by_test_id("blogcreate-textarea-contents-text-error")).to_be_visible()
+    # エラーメッセージの内容を検証
+    expect(page.get_by_test_id("blogcreate-input-title-error")).to_have_text("タイトルは必須です")
+    expect(page.get_by_test_id("blogcreate-textarea-contents-text-error")).to_have_text("本文は必須です")
+
+
+
+def test_create_blog_with_title_too_long(page: Page):
+    page.goto("http://frontend:5173/blogs/create")
+
+    # 201文字のタイトルを入力
+    long_title = "あ" * 201
+    page.get_by_test_id("blogcreate-input-title").fill(long_title)
+
+    # 本文は正常値を入力
+    page.get_by_test_id("blogcreate-textarea-contents-text").fill("本文の内容")
+
+    # 送信ボタンをクリック ← ブログ作成はされないはず
+    page.get_by_test_id("blogcreate-submit-btn").click()
+
+    # バリデーションエラーになるはずなので、メッセージがでているかの検証
+    expect(page.get_by_test_id("blogcreate-input-title-error")).to_be_visible()
+    # エラーメッセージの内容を検証
+    expect(page.get_by_text("タイトルは200文字以内で入力してください")).to_be_visible()
+    # 本文の入力欄についてのバリデーションエラーはでていないはず
+    expect(page.get_by_test_id("bblogcreate-textarea-contents-text-error")).not_to_be_visible()

--- a/playwright-mock/mocked_tests/blog/test_create.py
+++ b/playwright-mock/mocked_tests/blog/test_create.py
@@ -1,6 +1,7 @@
 import pytest
+import json
 from playwright.sync_api import Page, Route, Request, expect
-
+from playwright._impl._errors import TimeoutError
 #---バックエンドのモック---
 # 正常系なブログ作成用モック
 def handle_blog_create_201(route: Route, request: Request):
@@ -13,16 +14,31 @@ def handle_blog_create_201(route: Route, request: Request):
     else:
         route.continue_()
 
-# バリデーションエラー: 400)
+
 def handle_blog_create_400(route: Route, request: Request):
     if request.method == "POST" and "/api/v1/blogs/" in request.url:
         route.fulfill(
             status=400,
             content_type="application/json",
-            body='{"detail": "エラーが発生しました"}'
+            body='{"detail": "作成に失敗しました。"}'
         )
     else:
         route.continue_()
+# バリデーションエラー (バックエンドとしては400を返すべきだが、フロント側でバリデーションエラーならばバックエンドへリクエストできないはずなのでなにも返さない)     
+def handle_blog_create_invalid_input(route: Route, request: Request):
+    if request.method == "POST" and "/api/v1/blogs/" in request.url:
+        route.fulfill(
+            status=400,
+            content_type="application/json",
+            # body=json.dumps({
+            #     "title": ["この項目は空にできません。"],
+            #     "contents_text": ["この項目は空にできません。"]
+            # })
+            body=None
+        )
+    else:
+        route.continue_()
+
 # サーバーエラー: 500
 def handle_blog_create_500(route: Route, request: Request):
     if request.method == "POST" and "/api/v1/blogs/" in request.url:
@@ -55,10 +71,50 @@ def test_create_blog_success(page: Page):
 
 
 
-def test_create_blog_with_empty_fields(page: Page):
+def test_blog_create_success_request_response(page: Page):
+    """バックエンドからのリクエストとレスポンスを検証し、その内容からフロントエンドの挙動を確認する"""
+    # ブログ作成apiのモックを準備(正常系)
+    page.route("**/api/v1/blogs/", handle_blog_create_201)
+    # ブログ作成ページへ遷移
+    page.goto("http://frontend:5173/blogs/create")
+
+    # フォームに入力
+    page.get_by_test_id("blogcreate-input-title").fill("モックタイトル")
+    page.get_by_test_id("blogcreate-textarea-contents-text").fill("モック本文")
+
+    # ブログ作成apiへpostリクエスト → その結果のレスポンスをキャッチ
+    # with page.expect_response("**/api/v1/blogs/") as response_info:
+
+    # ↓はリクエストもレスポンスも両方とも受けとることができる書き方
+    with page.expect_request("**/api/v1/blogs/") as request_info, \
+        page.expect_response("**/api/v1/blogs/") as response_info:
+        # 作成ボタンをクリック
+        page.get_by_test_id("blogcreate-submit-btn").click()
+    # リクエストオブジェクト取得
+    request = request_info.value
+    # リクエストメソッドはPOSTのはず
+    assert request.method == "POST"
+    # レスポンスオブジェクト取得
+    response = response_info.value
+    # レスポンスのステータスコードは201のはず
+    assert response.status == 201
+    # レスポンスのJSONの中身を取得
+    data = response.json()
+    # レスポンスの内容を確認すす ブログ作成が成功しているので、作成されたブログの情報が返ってくるはず
+    assert data["id"] == 1
+    assert data["title"] == "モックタイトル"
+    assert data["contents_text"] == "モック本文"
+    # ブログ一覧ページに遷移していることを確認する
+    expect(page).to_have_url("http://frontend:5173/blogs")
+    expect(page.get_by_test_id("bloglist-section-title")).to_have_text("ブログ一覧")
+    # ブログ作成画面のエラーメッセージは表示されていないはず。
+    expect(page.get_by_test_id("blogcreate-backend-error-message")).not_to_be_visible()
+
+
+def test_blog_create_with_invalid_input(page: Page):
     """バリデーションエラー タイトル、本文ともに入力しない場合"""
     # このテストケースではブログ作成apiのモックをしてもしなくても結果が変わらないが一応準備
-    page.route("**/api/v1/blogs/", handle_blog_create_201)
+    page.route("**/api/v1/blogs/", handle_blog_create_invalid_input)
     page.goto("http://frontend:5173/blogs/create")
 
     # 何も入力せずに送信ボタンをクリック ← ブログ作成はされないはず
@@ -72,6 +128,26 @@ def test_create_blog_with_empty_fields(page: Page):
     expect(page.get_by_test_id("blogcreate-textarea-contents-text-error")).to_have_text("本文は必須です")
 
 
+def test_blog_create_no_request_if_invalid_input(page: Page):
+    """バリデーションエラー タイトル、本文ともに入力しないでブログ作成ボタンを押しても、fetchリクエスト自体が送信されないことを確認する"""
+    page.route("**/api/v1/blogs/", handle_blog_create_invalid_input)
+    page.goto("http://frontend:5173/blogs/create")
+
+    # タイトルや本文を入力しない（＝バリデーションNG）
+    page.get_by_test_id("blogcreate-input-title").fill("")
+    page.get_by_test_id("blogcreate-textarea-contents-text").fill("")    
+
+    # バックエンドへのfetchリクエストが送られないことを確認
+    with pytest.raises(TimeoutError):
+        with page.expect_request("**/api/v1/blogs/", timeout=1000):
+            # ここの部分ではas request_infoを使うことはできない
+            # ↓で作成ボタンを押しても、フロントバリデーションエラーが発生中はボタンを押してもリクエストが発生しないから。
+            page.get_by_test_id("blogcreate-submit-btn").click()
+
+    
+    # バリデーションエラーが表示されることを確認
+    expect(page.get_by_text("タイトルは必須です")).to_be_visible()
+    expect(page.get_by_text("本文は必須です")).to_be_visible()
 
 def test_create_blog_with_title_too_long(page: Page):
     """バリデーションエラー タイトルの文字列が長すぎる場合"""
@@ -86,8 +162,15 @@ def test_create_blog_with_title_too_long(page: Page):
     # 本文は正常値を入力
     page.get_by_test_id("blogcreate-textarea-contents-text").fill("本文の内容")
 
-    # 送信ボタンをクリック ← ブログ作成はされないはず
-    page.get_by_test_id("blogcreate-submit-btn").click()
+    # # 送信ボタンをクリック ← ブログ作成はされないはず
+    # page.get_by_test_id("blogcreate-submit-btn").click()
+
+    # バックエンドへのfetchリクエストが送られないことを確認
+    with pytest.raises(TimeoutError):
+        with page.expect_request("**/api/v1/blogs/", timeout=1000):
+            # ここの部分ではas request_infoを使うことはできない
+            # ↓で作成ボタンを押しても、フロントバリデーションエラーが発生中はボタンを押してもリクエストが発生しないから。
+            page.get_by_test_id("blogcreate-submit-btn").click()
 
     # バリデーションエラーになるはずなので、メッセージがでているかの検証
     expect(page.get_by_test_id("blogcreate-input-title-error")).to_be_visible()
@@ -123,12 +206,11 @@ def test_blog_create_request_payload(page: Page):
     }
 
 @pytest.mark.parametrize("handler,error_message,expect_backend_status", [
-    (handle_blog_create_201, "", 201),
-    (handle_blog_create_400, "エラーが発生しました", 400),
+    (handle_blog_create_400, "作成に失敗しました。", 400),
     (handle_blog_create_500, "Internal Server Error", 500),
 ])
-def test_blog_create_response_data(page: Page, handler, error_message, expect_backend_status):
-    """バックエンドからのレスポンスを検証し、その内容からフロントエンドの挙動を確認する"""
+def test_blog_create_failedcase_response_data(page: Page, handler, error_message, expect_backend_status):
+    """バックエンドからのエラーレスポンスが帰ってきた時のフロントエンドの挙動を確認する"""
     page.route("**/api/v1/blogs/", handler)
 
     page.goto("http://frontend:5173/blogs/create")
@@ -138,35 +220,43 @@ def test_blog_create_response_data(page: Page, handler, error_message, expect_ba
     page.get_by_test_id("blogcreate-textarea-contents-text").fill("テスト本文")
 
     # ブログ作成apiへpostリクエスト → その結果のレスポンスをキャッチ
-    with page.expect_response("**/api/v1/blogs/") as response_info:
+    # with page.expect_response("**/api/v1/blogs/") as response_info:
+
+    # ↓はリクエストもレスポンスも両方とも受けとることができる書き方
+    with page.expect_request("**/api/v1/blogs/") as request_info, \
+        page.expect_response("**/api/v1/blogs/") as response_info:
         # 送信ボタンをクリック
         page.get_by_test_id("blogcreate-submit-btn").click()
     
     # レスポンスオブジェクト取得
     response = response_info.value
-    # ステータスコード確認
+    # ステータスコード確認(= mockのエラーレスポンスが返ってくるはず)
     assert response.status == expect_backend_status
     # JSONレスポンスの中身確認
     data = response.json()
-    if expect_backend_status == 201:
-        # 成功時のレスポンス確認
-        assert data["id"] == 1
-        assert data["title"] == "モックタイトル"
-        assert data["contents_text"] == "モック本文"
-    elif expect_backend_status == 400:
+    if expect_backend_status == 400:
         # エラーメッセージが表示されるか確認
         expect(page.get_by_test_id("blogcreate-backend-error-message")).to_be_visible()
         # 400エラー時のレスポンス確認
-        assert data["detail"] == "エラーが発生しました"
+        assert data["detail"] == error_message       
         # エラーメッセージの内容を確認
         expect(page.get_by_test_id("blogcreate-backend-error-message")).to_have_text(error_message)
     elif expect_backend_status == 500:
         # エラーメッセージが表示されるか確認
         expect(page.get_by_test_id("blogcreate-backend-error-message")).to_be_visible()
         # サーバーエラー=500エラー時のレスポンス確認
-        assert data["detail"] == "Internal Server Error"
+        assert data["detail"] == error_message
         # エラーメッセージの内容を確認
         expect(page.get_by_test_id("blogcreate-backend-error-message")).to_have_text(error_message)        
 
 
+# 他にも　403（認可エラー）や 401（認証エラー）などのケースも考えられるが、今回は省略
 
+# 500エラーになるケースは、はdocker compose -f local.yml stop backendしてから、フロント側で正常にブログ作成をした場合、
+# POST http://localhost:8000/api/v1/blogs/ net::ERR_CONNECTION_REFUSED がフロントコンソールにでる
+# 一方バックエンドは起動していてもBlogViewSetクラスのcreateメソッドがraise Exceptionするだけだった場合でも起こすことができる
+# その場合は、 POST http://localhost:8000/api/v1/blogs/ 500 (Internal Server Error) がフロントコンソールにでる
+# どっちの場合でもフロントのBlogCcreate.vueのsubmitBlogメソッドのcatchブロックに入るので、errorMessage.valueに値が入る
+
+# 400エラーは、ブラウザからバックエンドに直接ブログ作成リクエストする際、不要なフィールドを含めてPOSTすると発生する(non_field_errorsが入っているレスポンス)
+# 単にフロントエンドで入力必須な欄を未記入にしてPOSTするだけでは、フロントバリデーションエラーで止まるだけ(=リクエスト自体が発生しない)。

--- a/playwright-mock/mocked_tests/blog/test_create.py
+++ b/playwright-mock/mocked_tests/blog/test_create.py
@@ -1,0 +1,31 @@
+import pytest
+from playwright.sync_api import Page, Route, Request, expect
+
+@pytest.mark.parametrize("route_status", [201])
+def test_create_blog_success(page: Page, route_status):
+    # モック: POST /api/v1/blogs/ に対して成功レスポンスを返す
+    def handle_blog_create(route: Route, request: Request):
+        assert request.method == "POST"
+        payload = request.post_data_json
+        assert "title" in payload
+        assert "contents_text" in payload
+        route.fulfill(
+            status=route_status,
+            content_type="application/json",
+            body='{"id": 1, "title": "モックタイトル", "contents_text": "モック本文"}'
+        )
+    
+    page.route("**/api/v1/blogs/", handle_blog_create)
+
+    # フロントエンドの作成画面へ遷移
+    page.goto("http://frontend:5173/blogs/create")
+
+    # 入力フォームにデータを入力
+    page.get_by_test_id("blogcreate-input-title").fill("モックタイトル")
+    page.get_by_test_id("blogcreate-textarea-contents-text").fill("モック本文")
+
+    # 送信ボタンをクリック
+    page.get_by_test_id("blogcreate-back-btn").click()
+
+    # 成功した場合の挙動を検証（例：トップページに戻る）
+    expect(page).to_have_url("http://frontend:5173/blogs")


### PR DESCRIPTION
# このPRで実現したこと

- バックエンドに「ブログ作成」用apiを追加(`http://localhost:8000/api/v1/blogs/`にPOSTリクエストで利用)

https://github.com/user-attachments/assets/39878ac1-7e51-4d05-b837-57def32212c1

- バックエンドの単体テストを追加
- フロントエンドにブログ作成画面を追加(`http://localhost:5173/blogs/create`にアクセス)
- フロントエンドのmockedテストを追加





