### PR TITLE
共通コンポーネント 検索用入力欄と検索開始ボタンを作成

### DIFF
--- a/frontend/src/components/AppSearchInput.vue
+++ b/frontend/src/components/AppSearchInput.vue
@@ -8,11 +8,13 @@
             @keydown.enter="submitSearch"
             class="border px-3 py-2 rounded w-full"
             :placeholder="placeholder"
+            :data-testid="`${props.dataTestid}-input`"
         />
         <!-- 検索ボタン。クリック時にsubmitSearch関数を実行 -->
         <button
             @click="submitSearch"
             class="px-4 py-2 rounded bg-sky-400 text-white hover:bg-sky-500"
+            :data-testid="`${props.dataTestid}-btn`"
         >
         検索
         </button>
@@ -20,12 +22,18 @@
 </template>
   
 <script setup lang="ts">
-import { ref, defineEmits, defineProps } from 'vue'
-// 親コンポーネントで受け取るpropsとしては、入力欄のplaceholder
-const props = defineProps<{
-    placeholder?: string
-}>()
+import { ref, defineEmits, defineProps,withDefaults } from 'vue'
+import { computed } from 'vue'
+// 親コンポーネントで受け取るpropsとしては、入力欄のplaceholderとdateTestid
 
+const props = withDefaults(defineProps<{
+    placeholder?: string,
+    dataTestid: string  // ← シングルクォートで囲って定義できる（ハイフンを含む名前だから）
+}>(), {
+    // 個々に記述しているのはデフォルト値(変数名にシングルクォートを使う場合についても一緒)
+    placeholder: '検索',
+    dataTestid: 'search-bar'
+})
 
 // emitは、Vueのコンポーネントから親コンポーネントにイベントを発火するためのもの
 // このコンポーネントは "search" イベントを親に向けて発行する。発行した際、親に渡す値の型はstring型=検索文字列

--- a/frontend/src/components/AppSearchInput.vue
+++ b/frontend/src/components/AppSearchInput.vue
@@ -22,8 +22,8 @@
 </template>
   
 <script setup lang="ts">
-import { ref, defineEmits, defineProps,withDefaults } from 'vue'
-import { computed } from 'vue'
+// defineEmits, defineProps,withDefaultsはvueからimportしなくてもいいようになっている
+import { ref } from 'vue'
 // 親コンポーネントで受け取るpropsとしては、入力欄のplaceholderとdateTestid
 
 const props = withDefaults(defineProps<{

--- a/frontend/src/components/AppSearchInput.vue
+++ b/frontend/src/components/AppSearchInput.vue
@@ -27,21 +27,33 @@ const props = defineProps<{
 }>()
 
 
-// emitイベントの定義。
-// このコンポーネントは "search" イベントを親に向けて発行する。引数は文字列（検索語）
+// emitは、Vueのコンポーネントから親コンポーネントにイベントを発火するためのもの
+// このコンポーネントは "search" イベントを親に向けて発行する。発行した際、親に渡す値の型はstring型=検索文字列
 const emit = defineEmits<{
     (e: 'search', value: string): void
 }>()
+// 上記はjsとして記述するなら、defineEmits()だけになるが、defineEmits自体がジェネリクス関数として定義されている。
+// なので、<>の部分は「emitにいれる引数の型」を定義することになる。で、指定したものは{} = オブジェクトだがそれは「関数型(シグネチャ型)」
+// 「戻り値はなし(void)で、"search"というイベントが発生した時、親コンポーネントへ渡す値はstring型に決める」というもの
+// 「引数の型だけ決めておいて、実際の引数がない」のはdefineEmitsの仕様。あくまで、「イベント名を指定し、それが発火した時に渡る値の型だけ決めておきたい」だけだから。
+// 下のsubmitSearchの中身がそのようになっている。
+// そして、親コンポーネントでは@search=handleSearchと書いてあるので、「親コンポーネントのhandleSearchメソッドでは、「子コンポーネントでsearchイベント発生時用に準備していた値(keyword.value)」が引数としてわたってきて使えるようになる。」
 
-// 入力フォームにバインドする状態(keyword)
+
+// 入力フォームにバインド(v-model)する状態(keyword)
 const keyword = ref('') // 初期状態は空文字列
 
 const submitSearch = () => {
-    emit('search', keyword.value);  // 現在の入力値と"search"イベントを親コンポーネントへ渡す
-    // 親コンポーネントにて、このコンポーネントを使う際は、@search="実行したい関数"のようにしている
-    //  = ここが実行されたら、searchイベントが親コンポーネントに飛び、その「実行したい関数」が実行される
-    //　そのsearchイベントによって実行される関数に引数で渡るのがkeyword.valueです。
+    emit('search', keyword.value);  // 現在入力されている値を "search" イベントとして親に送信する
+    // 親コンポーネントでは、このコンポーネントに @search="handleSearch" のように登録しておくことで、
+    // この "search" イベントが発火されたとき、親側の handleSearch 関数が実行される。
+    // handleSearch 関数の引数には、ここで emit した keyword.value の値（string型）が渡される
 
 }
 </script>
-  
+
+
+<!-- https://typescriptbook.jp/reference/values-types-variables/literal-types -->
+<!-- https://typescriptbook.jp/reference/generics -->
+<!-- https://typescriptbook.jp/reference/generics/type-variables -->
+<!-- https://typescriptbook.jp/reference/functions/function-type-declaration#%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E6%A7%8B%E6%96%87%E3%81%AB%E3%82%88%E3%82%8B%E9%96%A2%E6%95%B0%E3%81%AE%E5%9E%8B%E5%AE%A3%E8%A8%80 -->

--- a/frontend/src/components/AppSearchInput.vue
+++ b/frontend/src/components/AppSearchInput.vue
@@ -1,0 +1,47 @@
+<template>
+    <div class="flex items-center gap-2">
+        <!-- テキスト入力欄。入力された値はv-modelでこのコンポーネントのscrtiptで定義のref変数keywordと同期。-->
+         <!--Enterキー押下時にsubmitSearch関数を実行 -->
+        <input
+            type="text"
+            v-model="keyword"
+            @keydown.enter="submitSearch"
+            class="border px-3 py-2 rounded w-full"
+            :placeholder="placeholder"
+        />
+        <!-- 検索ボタン。クリック時にsubmitSearch関数を実行 -->
+        <button
+            @click="submitSearch"
+            class="px-4 py-2 rounded bg-sky-400 text-white hover:bg-sky-500"
+        >
+        検索
+        </button>
+    </div>
+</template>
+  
+<script setup lang="ts">
+import { ref, defineEmits, defineProps } from 'vue'
+// 親コンポーネントで受け取るpropsとしては、入力欄のplaceholder
+const props = defineProps<{
+    placeholder?: string
+}>()
+
+
+// emitイベントの定義。
+// このコンポーネントは "search" イベントを親に向けて発行する。引数は文字列（検索語）
+const emit = defineEmits<{
+    (e: 'search', value: string): void
+}>()
+
+// 入力フォームにバインドする状態(keyword)
+const keyword = ref('') // 初期状態は空文字列
+
+const submitSearch = () => {
+    emit('search', keyword.value);  // 現在の入力値と"search"イベントを親コンポーネントへ渡す
+    // 親コンポーネントにて、このコンポーネントを使う際は、@search="実行したい関数"のようにしている
+    //  = ここが実行されたら、searchイベントが親コンポーネントに飛び、その「実行したい関数」が実行される
+    //　そのsearchイベントによって実行される関数に引数で渡るのがkeyword.valueです。
+
+}
+</script>
+  

--- a/frontend/src/components/AppTrasitionPageButton.vue
+++ b/frontend/src/components/AppTrasitionPageButton.vue
@@ -20,7 +20,7 @@
 // transitionPageToの関数ではprops.toが指定されていればそのURLに遷移し、指定されていなければ'/blogs'に遷移するようにしています。
 // props.toの値の指定の仕方は、<AppTransitionPageButton to="/blogs" text="ブログ一覧へ戻る" date-testid="some-datetest-id"/>のようにします。
 import { useRouter } from 'vue-router'
-import { defineProps,withDefaults } from 'vue'
+// defineEmits, defineProps,withDefaultsはvueからimportしなくてもいいようになっている
 
 // 明示的に受け取る props（その他は $attrs）
 // 特にdatatestidはpropsで渡すことができないのでattrsで受け取るようにしています。

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,6 +3,15 @@ import './style.css'
 import App from './App.vue'
 import router from './router' // このファイルからみてrouterディレクトリ内のtsファイルなどから、変数routerをimport
 
+// 共通コンポーネント
+import AppTrasitionPageButton from '@/components/AppTrasitionPageButton.vue'
+import AppSearchInput from '@/components/AppSearchInput.vue'
+
 const app = createApp(App)   // vueアプリを作成し変数に格納
+
+// 共通コンポーネントを、その個数分appに登録 = 各vueファイルで共通コンポーネントをimportせずに使えるようにする
+app.component('AppTrasitionPageButton', AppTrasitionPageButton) 
+app.component('AppSearchInput', AppSearchInput) 
+
 app.use(router)              // アプリとしてvue-routerを使用する設定
 app.mount('#app')

--- a/frontend/src/pages/BlogCreate.vue
+++ b/frontend/src/pages/BlogCreate.vue
@@ -46,8 +46,6 @@ import { ref, computed } from "vue"
 import { useRouter } from "vue-router"
 import { useForm, useField } from 'vee-validate'
 import * as yup from 'yup'
-// 共通コンポーネントである「遷移ボタン」をインポート
-import AppTrasitionPageButton from '@/components/AppTrasitionPageButton.vue'
 
 // スキーマ定義=フォーム内パーツのバリデーションルールを定義し、yup ライブラリを使用してスキーマを作成
 // titleについては、必須項目であること、最大文字数200文字であることを指定

--- a/frontend/src/pages/BlogList.vue
+++ b/frontend/src/pages/BlogList.vue
@@ -74,10 +74,7 @@
 <script setup lang="ts">
   import { ref, onMounted, watch } from "vue";
   import moment from "moment"
-  // 共通コンポーネント
-  import AppTrasitionPageButton from '@/components/AppTrasitionPageButton.vue'
-  import AppSearchInput from '@/components/AppSearchInput.vue'
- 
+   
   const baseURL = import.meta.env.VITE_API_BASE_URL;
   const blogs = ref([]);
   const searchword = ref("");

--- a/frontend/src/pages/BlogList.vue
+++ b/frontend/src/pages/BlogList.vue
@@ -17,7 +17,7 @@
         </select>
       </div>
       <!-- 共通コンポーネントのブログ検索欄 searchイベント発生時にはhandleSearchを実行する-->
-      <AppSearchInput placeholder="検索" @search="handleSearch"/>
+      <AppSearchInput placeholder="検索" @search="handleSearch" dataTestid="bloglist-search"/>
       <!-- ブログ作成画面への遷移ボタン -->
       <AppTrasitionPageButton to="/blogs/create" data-testid="bloglist-transition-blogcreate-btn">
           ブログ作成画面へ

--- a/frontend/tests/unit/AppSearchInput.test.ts
+++ b/frontend/tests/unit/AppSearchInput.test.ts
@@ -4,7 +4,12 @@ import AppSearchInput from '@/components/AppSearchInput.vue' // ←ファイル�
 
 describe('AppSearchInput.vue', () => {
   test('初期状態では入力欄は空文字', () => {
-    const wrapper = mount(AppSearchInput)
+    const wrapper = mount(AppSearchInput,{
+      props: {
+        placeholder: 'キーワードを入力してください',
+        dataTestid: 'test-search',
+      },
+    })
 
     const input = wrapper.get('input')
     expect((input.element as HTMLInputElement).value).toBe('')
@@ -14,6 +19,7 @@ describe('AppSearchInput.vue', () => {
     const wrapper = mount(AppSearchInput, {
       props: {
         placeholder: 'キーワードを入力してください',
+        dataTestid: 'test-search',
       },
     })
 
@@ -22,7 +28,12 @@ describe('AppSearchInput.vue', () => {
   })
 
   test('入力するとv-modelが反映される', async () => {
-    const wrapper = mount(AppSearchInput)
+    const wrapper = mount(AppSearchInput,{
+      props: {
+        placeholder: 'キーワードを入力してください',
+        dataTestid: 'test-search',
+      },
+    })
 
     const input = wrapper.get('input')
     await input.setValue('Vue3テスト')
@@ -32,7 +43,12 @@ describe('AppSearchInput.vue', () => {
   })
 
   test('ボタンをクリックするとsearchイベントがemitされる', async () => {
-    const wrapper = mount(AppSearchInput)
+    const wrapper = mount(AppSearchInput,{
+      props: {
+        placeholder: 'キーワードを入力してください',
+        dataTestid: 'test-search',
+      },
+    })
 
     const input = wrapper.get('input')
     await input.setValue('クリックで検索')
@@ -46,7 +62,12 @@ describe('AppSearchInput.vue', () => {
   })
 
   test('Enterキー押下でもsearchイベントがemitされる', async () => {
-    const wrapper = mount(AppSearchInput)
+    const wrapper = mount(AppSearchInput,{
+      props: {
+        placeholder: 'キーワードを入力してください',
+        dataTestid: 'test-search',
+      },
+    })
 
     const input = wrapper.get('input')
     await input.setValue('エンターで検索')

--- a/frontend/tests/unit/AppSearchInput.test.ts
+++ b/frontend/tests/unit/AppSearchInput.test.ts
@@ -1,0 +1,60 @@
+import { mount } from '@vue/test-utils'
+import { describe, test, expect, vi } from 'vitest'
+import AppSearchInput from '@/components/AppSearchInput.vue' // ←ファイルパスは適宜変更してください
+
+describe('AppSearchInput.vue', () => {
+  test('初期状態では入力欄は空文字', () => {
+    const wrapper = mount(AppSearchInput)
+
+    const input = wrapper.get('input')
+    expect((input.element as HTMLInputElement).value).toBe('')
+  })
+
+  test('propsでplaceholderが反映される', () => {
+    const wrapper = mount(AppSearchInput, {
+      props: {
+        placeholder: 'キーワードを入力してください',
+      },
+    })
+
+    const input = wrapper.get('input')
+    expect(input.attributes('placeholder')).toBe('キーワードを入力してください')
+  })
+
+  test('入力するとv-modelが反映される', async () => {
+    const wrapper = mount(AppSearchInput)
+
+    const input = wrapper.get('input')
+    await input.setValue('Vue3テスト')
+
+    // 入力した値が input に反映されていることを確認
+    expect((input.element as HTMLInputElement).value).toBe('Vue3テスト')
+  })
+
+  test('ボタンをクリックするとsearchイベントがemitされる', async () => {
+    const wrapper = mount(AppSearchInput)
+
+    const input = wrapper.get('input')
+    await input.setValue('クリックで検索')
+
+    const button = wrapper.get('button')
+    await button.trigger('click')
+
+    // emitが発火しているか、payloadが正しいか
+    expect(wrapper.emitted('search')).toBeTruthy()
+    expect(wrapper.emitted('search')![0]).toEqual(['クリックで検索'])
+  })
+
+  test('Enterキー押下でもsearchイベントがemitされる', async () => {
+    const wrapper = mount(AppSearchInput)
+
+    const input = wrapper.get('input')
+    await input.setValue('エンターで検索')
+
+    // Enterキーイベントをシミュレート
+    await input.trigger('keydown.enter')
+
+    expect(wrapper.emitted('search')).toBeTruthy()
+    expect(wrapper.emitted('search')![0]).toEqual(['エンターで検索'])
+  })
+})

--- a/frontend/tests/unit/AppTransitionPageButton.test.ts
+++ b/frontend/tests/unit/AppTransitionPageButton.test.ts
@@ -12,7 +12,9 @@ describe('AppTrasitionPageButton', () => {
 
     const router = createRouter({
         history: createWebHistory(),  // HTML5の履歴モード
-        routes: [] // テストでは実際のルートは必要ない（ルーティング自体はしないので）
+        routes: [
+          { path: '/', component: { template: '<div>Home</div>' } }
+        ] // テストでは実際のルートは必要ない（ルーティング自体はしないので）
     })
 
     // 実際の router.push を、上で作ったモック関数に差し替える

--- a/frontend/tests/unit/BlogCreate.test.ts
+++ b/frontend/tests/unit/BlogCreate.test.ts
@@ -6,13 +6,30 @@ import { describe, test, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 // テスト対象のブログ作成画面の Vue コンポーネント。
 import BlogCreate from '@/pages/BlogCreate.vue'
+import { createRouter, createWebHistory } from 'vue-router'
+// vitestでは、main.tsが読み込まれないので共通コンポーネントをインポート
+import AppTrasitionPageButton from '@/components/AppTrasitionPageButton.vue'
+// 以下を用意して、BlogCreate.vueをマウントする時にpluginとして渡さないと、警告がでる
+const router = createRouter({
+    history: createWebHistory(),  // HTML5の履歴モード
+    routes: [
+      { path: '/', component: { template: '<div>Home</div>' } }
+    ] // テストでは実際のルートは必要ない（ルーティング自体はしないので）
+})
 
 // 以下describeが、その中野testをまとめるためのもの。
 describe('BlogCreate.vue - 作成ボタンの状態制御', () => {
     // testは、テストケースを定義するための関数。
     test('フォームが有効なとき、作成ボタンは有効化されスタイルが変わる', async () => {
         //BlogCreate.vue をマウント（仮想DOMに展開）し、wrapper オブジェクトを取得。
-        const wrapper = mount(BlogCreate)
+        const wrapper = mount(BlogCreate, {
+            global: {
+                plugins: [router],
+                components: {
+                    AppTrasitionPageButton,
+                },
+            },
+          })
         // ボタン要素を取得　data-testid を使って「作成」ボタン要素を、全体DOMのwrapperから取得。
         const submitBtn = wrapper.get('[data-testid="blogcreate-submit-btn"]')
         // フィールドに入力をしていない状態だと、作成ボタンは灰色で押せないはず


### PR DESCRIPTION
- フロントエンドの共通コンポーネントとして、検索用入力欄と、検索開始ボタン
  - defineEmitsとdefinePropsを使い、親、子コンポーネント間での入力値やplaceholderの受け渡しに対応
- [共通コンポーネントとして以前作成した遷移ボタン](https://github.com/rooreckless/djangoblog/pull/9)も含め、共通コンポーネントを作成しても、「各vueファイルで個別にimportする必要がない」ように対応
  - コンポーネントを追加するごとに、main.tsにてapp.componentsによる読み込みが必要だが。 
- 今回作成した共通コンポーネントについてにフロントエンドユニットテスト(vitest)を作成
- いままで作成してきたフロントエンドユニットテストでは警告がでることがあったが、警告がでないように対処