### PR TITLE
【GithubActionsでCI】.github/workflowsに、E2Eテストの手動実行用のymlを作成し、運用方法を作成 

### DIFF
--- a/.github/workflows/manually-e2e-githubactions.yml
+++ b/.github/workflows/manually-e2e-githubactions.yml
@@ -2,14 +2,14 @@ name: Real E2E Tests MANUALLY
 
 on:
   workflow_dispatch:  # ← このワークフローは手動実行のみ
-
-# 実行対象ブランチを制限することも可能（任意）
-  inputs:
-    # 作業ブランチではこのワークフローを動実行させない。developmentかmainのみ
-    branch:
-      type: choice
-      options: [development, main]
-      default: development
+    inputs:
+      # 実行対象ブランチを制限することも可能
+      # 作業ブランチではこのワークフローを手動実行させない。developmentかmainのみ
+      branch:
+        description: '実行ブランチを選択（作業ブランチではなく development や main）'
+        type: choice
+        options: [development, main]
+        default: development
 
 jobs:
   e2e-real-tests:
@@ -20,7 +20,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+        # 手動実行で選択したブランチをチェックアウト
+        with:
+          ref: ${{ inputs.branch }}
+    
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/manually-e2e-githubactions.yml
+++ b/.github/workflows/manually-e2e-githubactions.yml
@@ -8,7 +8,7 @@ on:
       branch:
         description: '実行ブランチを選択（作業ブランチではなく development や main）'
         type: choice
-        options: [development, main]
+        options: [development, main,e2etest-running-by-manually-githubactions]
         default: development
 
 jobs:

--- a/.github/workflows/manually-e2e-githubactions.yml
+++ b/.github/workflows/manually-e2e-githubactions.yml
@@ -8,7 +8,7 @@ on:
       branch:
         description: '実行ブランチを選択（作業ブランチではなく development や main）'
         type: choice
-        options: [development, main,e2etest-running-by-manually-githubactions]
+        options: [development, stage, prod_sub, main]
         default: development
 
 jobs:

--- a/.github/workflows/manually-e2e-githubactions.yml
+++ b/.github/workflows/manually-e2e-githubactions.yml
@@ -3,6 +3,14 @@ name: Real E2E Tests MANUALLY
 on:
   workflow_dispatch:  # ← このワークフローは手動実行のみ
 
+# 実行対象ブランチを制限することも可能（任意）
+  inputs:
+    # 作業ブランチではこのワークフローを動実行させない。developmentかmainのみ
+    branch:
+      type: choice
+      options: [development, main]
+      default: development
+
 jobs:
   e2e-real-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/manually-e2e-githubactions.yml
+++ b/.github/workflows/manually-e2e-githubactions.yml
@@ -1,7 +1,7 @@
-name: Run Workflow real E2E tests manually
+name: Real E2E Tests MANUALLY
 
 on:
-  workflow_dispatch:  # ← 手動実行のみ
+  workflow_dispatch:  # ← このワークフローは手動実行のみ
 
 jobs:
   e2e-real-tests:
@@ -26,14 +26,8 @@ jobs:
       - name: Docker compose up with e2e.yml
         run: docker compose -f e2e.yml up -d
 
-      # - name: Run migrations
-      #   run: docker compose -f e2e.yml run --rm backend python manage.py migrate
-
       - name: Run migrations and create superuser and test data
         run: sh scripts/e2e/setup-script.sh
-
-      # - name: Run real E2E tests
-      #   run: docker compose -f e2e.yml run --rm playwright-real pytest real_tests
 
       - name: Run real E2E tests script
         run: sh scripts/e2e/e2etest-script.sh

--- a/.github/workflows/manually-e2e-githubactions.yml
+++ b/.github/workflows/manually-e2e-githubactions.yml
@@ -1,4 +1,4 @@
-name: Run real E2E tests manually
+name: Run Workflow real E2E tests manually
 
 on:
   workflow_dispatch:  # ← 手動実行のみ

--- a/.github/workflows/manually-e2e-githubactions.yml
+++ b/.github/workflows/manually-e2e-githubactions.yml
@@ -1,0 +1,43 @@
+name: Run real E2E tests manually
+
+on:
+  workflow_dispatch:  # ← 手動実行のみ
+
+jobs:
+  e2e-real-tests:
+    runs-on: ubuntu-latest
+    environment:
+      name: EnvManuallyE2EtestByGithubActions  # Secretsを読み込む環境名
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create .envs files
+        run: |
+          mkdir -p .envs/e2e
+          echo "${{ secrets.DJANGO_ENV_FILE }}" > .envs/e2e/django
+          echo "${{ secrets.POSTGRES_ENV_FILE }}" > .envs/e2e/postgres
+          echo "${{ secrets.FRONTEND_ENV_FILE }}" > .envs/e2e/frontend
+
+      - name: Docker compose up with e2e.yml
+        run: docker compose -f e2e.yml up -d
+
+      # - name: Run migrations
+      #   run: docker compose -f e2e.yml run --rm backend python manage.py migrate
+
+      - name: Run migrations and create superuser and test data
+        run: sh scripts/e2e/setup-script.sh
+
+      # - name: Run real E2E tests
+      #   run: docker compose -f e2e.yml run --rm playwright-real pytest real_tests
+
+      - name: Run real E2E tests script
+        run: sh scripts/e2e/e2etest-script.sh
+
+      - name: Docker compose down
+        if: always()
+        run: docker compose -f e2e.yml down

--- a/playwright-real/dockerfile/local/Dockerfile
+++ b/playwright-real/dockerfile/local/Dockerfile
@@ -8,7 +8,8 @@ COPY ./backend/requirements/local.txt /app/requirements-django.txt
 RUN pip install --upgrade pip && pip install -r requirements-e2e-real.txt && pip install -r requirements-django.txt
 
 # Playwrightのブラウザをインストール（必要に応じて）
-RUN playwright install
+# chromiumだけ指定してるが、しなかったらChromiumと、Chromium HeadlessとFirefoxとWebkitのダウンロード = 時間かかりすぎる
+RUN playwright install chromium
 
 # ----
 # 【このplaywrightコンテナを使ったテストを実施する方法】


### PR DESCRIPTION
# このPRで実現したこと

[このアプリケーションでE2Eテストを実行する](https://github.com/rooreckless/djangoblog/pull/5)を、GithubActionsによって、「手動で」実施できるようになった。

現状は、ワークフローファイルにあるように、`develop` , `main` , `stage` , `prod_sub`ブランチの内容について、手動で実施することを想定している。

また、このE2Eテストについては現状は、[CI用のワークフローを作成](https://github.com/rooreckless/djangoblog/pull/11)とは違い、
「全passedだろうが全failedだろうが、開発には影響しない」状態としている。

## E2EテストをgithubActionsで手動実行するための手順

![スクリーンショット 2025-05-01 121944](https://github.com/user-attachments/assets/c9bb523b-3231-4484-9e4f-76c4e36d4c09)

上記画像の1～4までクリック・選択し、最後に`RUN Workflow`を押す。

特に2では、「手動実行用ワークフローを選ぶこと」と、4では実行するブランチを選択する必要がある。

## 実施したこと

- Githubリポジトリで、E2Eテスト用のEnvironment Secretesの設定 : 使用している.envファイルがlocalのものとは異なるためである。(手順は[CI用のワークフローを作成](https://github.com/rooreckless/djangoblog/pull/11)の時と同じだが、対象ファイルが違うだけ。)
- 新しいワークフローファイル`manually-e2e-githubactions.yml`を作成
  - 特にこのファイルは、`on.workflow_dispatch`が設定されており、「GithubのリポジトリページのActionsから手動実行する」ようにしている(`on.pull_request`にしていたのはCI用)
  - `on.workflow_dispatch.inputs.branch.options`では、実行するブランチを限定。これがUI上でも選択肢になる。
- E2Eテストの実行は、UIから`RUN Workflow`を押した時点から、3m30s程度(1テストケースのみ)で終わる。そのために、`playwright-real/dockerfile/local/Dockerfile`では、`RUN playwright install`から、`RUN playwright install chromium`に変え、対象ブラウザからfirefoxとsafariを排除している。