### PR TITLE
development.yml環境でもテストができるようにする

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -170,10 +170,8 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-# Vueアプリ（localhost:5173）からのアクセスを許可
-# CORS_ALLOWED_ORIGINS = [
-#     "http://localhost:5173",
-# ]
+# Vueアプリ（ローカル=vite開発サーバー=localhost:5173、develop=nginx=localhost:8080）からのアクセスを許可する必要があるので、
+# .envsの各環境変数ファイルにカンマ区切りで入れてください
 CORS_ALLOWED_ORIGINS = os.getenv("DJANGO_CORS_ALLOWED_ORIGINS_LIST").split(',')
 
 # OPTIONS リクエストに対応

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -171,9 +171,10 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Vueアプリ（localhost:5173）からのアクセスを許可
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",
-]
+# CORS_ALLOWED_ORIGINS = [
+#     "http://localhost:5173",
+# ]
+CORS_ALLOWED_ORIGINS = os.getenv("DJANGO_CORS_ALLOWED_ORIGINS_LIST").split(',')
 
 # OPTIONS リクエストに対応
 CORS_ALLOW_HEADERS = list(default_headers) + [

--- a/backend/dockerfile/development/Dockerfile
+++ b/backend/dockerfile/development/Dockerfile
@@ -1,11 +1,12 @@
 FROM python:3.12-slim
 
+# Pythonが .pyc ファイル（バイトコードキャッシュ）を生成しないようにする
 ENV PYTHONDONTWRITEBYTECODE=1
+# Pythonの出力をバッファリングしない（= 常に即時出力する=docker logsに即時反映される）
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-# COPY backend/ /app/
 COPY ./backend/requirements/development.txt /app/requirements/development.txt
 
 RUN pip install --upgrade pip && pip install -r /app/requirements/development.txt

--- a/backend/dockerfile/development/Dockerfile
+++ b/backend/dockerfile/development/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# COPY backend/ /app/
+COPY ./backend/requirements/development.txt /app/requirements/development.txt
+
+RUN pip install --upgrade pip && pip install -r /app/requirements/development.txt
+
+# gunicornのインストールは requirements に含めてください
+
+CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/backend/dockerfile/local/Dockerfile
+++ b/backend/dockerfile/local/Dockerfile
@@ -1,4 +1,10 @@
 FROM python:3.12.9-slim
+
+# Pythonが .pyc ファイル（バイトコードキャッシュ）を生成しないようにする
+ENV PYTHONDONTWRITEBYTECODE=1
+# Pythonの出力をバッファリングしない（= 常に即時出力する=docker logsに即時反映される）
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 COPY ./backend/requirements/local.txt /app/requirements/local.txt
 RUN pip install --upgrade pip && pip install -r /app/requirements/local.txt

--- a/backend/dockerfile/local/Dockerfile
+++ b/backend/dockerfile/local/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12.9-slim
 WORKDIR /app
 COPY ./backend/requirements/local.txt /app/requirements/local.txt
-RUN pip install -r /app/requirements/local.txt
+RUN pip install --upgrade pip && pip install -r /app/requirements/local.txt
 
 #--0 バックエンドで最初にやったこと--
 # 1.docker-compose -f local.yml run --rm backend /bin/bashでログイン後、pip install でパッケージインストール → その後pip freeze > requirements/local.txtでtext化

--- a/backend/requirements/development.txt
+++ b/backend/requirements/development.txt
@@ -1,0 +1,31 @@
+asgiref==3.8.1
+attrs==25.3.0
+dj-rest-auth==7.0.1
+Django==5.1.7
+django-allauth==65.5.0
+django-cors-headers==4.7.0
+django-extensions==3.2.3
+django-filter==25.1
+django-storages==1.14.5
+djangorestframework==3.15.2
+drf-spectacular==0.28.0
+inflection==0.5.1
+jsonschema==4.23.0
+jsonschema-specifications==2024.10.1
+PyYAML==6.0.2
+referencing==0.36.2
+rpds-py==0.23.1
+sqlparse==0.5.3
+typing_extensions==4.12.2
+uritemplate==4.1.1
+psycopg[binary]==3.2.6 # https://github.com/psycopg/psycopg
+#--test用に追加されたライブラリ--
+pytest==8.3.5
+pytest-xdist==3.6.1
+pytest-sugar==1.0.0
+pytest-mock==3.14.0
+pytest-django==4.10.0
+factory_boy==3.3.3
+# werkzeug==3.1.3
+#--develpment環境ではdjango開発サーバーではなくgunicornで動かすため追加
+gunicorn

--- a/backend/requirements/development.txt
+++ b/backend/requirements/development.txt
@@ -28,4 +28,4 @@ pytest-django==4.10.0
 factory_boy==3.3.3
 # werkzeug==3.1.3
 #--develpment環境ではdjango開発サーバーではなくgunicornで動かすため追加
-gunicorn
+gunicorn==23.0.0

--- a/development.yml
+++ b/development.yml
@@ -4,16 +4,22 @@ services:
     build:
       context: .  # このサービスについてはビルド時はfrontendを基準ディレクトリにするのではなく、このymlファイルがある場所になります。
       dockerfile: ./frontend/dockerfile/development/Dockerfile
+      args:
+        # VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+        VITE_API_BASE_URL: http://localhost:8000
     ports:
       - "8080:80"
     volumes:
       # - ./frontend:/app  # ホストの ./frontend をコンテナの /app にマウント（コード変更が即反映される）<- いらない。vite開発サーバーはdevelopmentでは使わないから
       - ./front_nginx:/front_nginx
       - node_modules:/app/node_modules  # node_modules はボリュームで分離（ホストと衝突を避ける）ただしこのディレクトリはroot所有者になる。
+    env_file:
+      - ./.envs/development/frontend
   playwright-mock:
     build:
       context: .
       dockerfile: ./playwright-mock/dockerfile/local/Dockerfile
+    container_name: djangoblog_development_playwright-mock
     profiles:
       - e2e-mock
     depends_on:
@@ -23,6 +29,52 @@ services:
       - ./.envs/development/frontend
     volumes:
       - ./playwright-mock:/app  # ← playwright-mock の中の mocked_tests をマウント
+  backend_gunicorn:
+    build:
+      context: .
+      dockerfile: ./backend/dockerfile/development/Dockerfile
+    image: djangoblog_development_backend_img
+    container_name: djangoblog_development_backend_gunicorn
+    restart: always
+    user: "${UID:-1000}:${GID:-1000}"
+    # depends_on:
+    #   - postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - ./.envs/development/django
+      - ./.envs/development/postgres
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+      # 以下はバックエンドディレクトリの外にあるpytestファイルを、コンテナのapp内に置かないとテストができないのでマウント
+      # - ./pytest.ini:/app/pytest.ini
+    ports:
+      - "8000:8000"
+    command: python manage.py runserver 0.0.0.0:8000
+  postgres:
+    build:
+      context: ./postgres
+      dockerfile: ./Dockerfile
+    image: djangoblog_development_postgres_img
+    container_name: djangoblog_development_postgres
+    restart: always
+    env_file:
+      - ./.envs/development/postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    # user: "${UID:-1000}:${GID:-1000}" #<- postgresにはこれはかけない
+    healthcheck:
+      #ヘルスチェック(postgresが正常に動作しているかどうか)は以下のスクリプトを実行して行う
+      # test: ["CMD", "/usr/local/bin/check-db.sh"]
+      # スクリプトファイルではなく、直接コマンドを実行。ダブルドルにしておくのは、composeファイル内でのエスケープのため
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 volumes:
   db_data:
   node_modules:  # Vueプロジェクトの依存ファイルを保持するボリューム

--- a/development.yml
+++ b/development.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8080:80"
     volumes:
-      - ./frontend:/app  # ホストの ./frontend をコンテナの /app にマウント（コード変更が即反映される）
+      # - ./frontend:/app  # ホストの ./frontend をコンテナの /app にマウント（コード変更が即反映される）<- いらない。vite開発サーバーはdevelopmentでは使わないから
       - ./front_nginx:/front_nginx
       - node_modules:/app/node_modules  # node_modules はボリュームで分離（ホストと衝突を避ける）ただしこのディレクトリはroot所有者になる。
 volumes:

--- a/development.yml
+++ b/development.yml
@@ -67,7 +67,7 @@ services:
       # - ./pytest.ini:/app/pytest.ini
     ports:
       - "8000:8000"
-    command: python manage.py runserver 0.0.0.0:8000
+    command: gunicorn config.wsgi:application --bind 0.0.0.0:8000
   postgres:
     build:
       context: ./postgres

--- a/development.yml
+++ b/development.yml
@@ -1,20 +1,37 @@
 services:
-  # マルチステージビルドなフロントエンドコンテナ (最終的に動くのはnginxだが、node.jsでviteをビルドしてから、nginxで配信する)
-  front_nginx:
+  frontend:
+    #このfrontendサービスは npm run buildのためだけのサービス
+    # docker compose -f development.yml run --rm frontend コマンドでビルド
+    # ↓
+    # frontend/distにビルド済みデータが作成される
     build:
-      context: .  # このサービスについてはビルド時はfrontendを基準ディレクトリにするのではなく、このymlファイルがある場所になります。
-      dockerfile: ./frontend/dockerfile/development/Dockerfile
+      context: ./frontend
+      dockerfile: ./dockerfile/development/Dockerfile
       args:
-        # VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+        # npm run build時に使う環境変数 = バックエンドへのfetch先
+        # ここに記述するので、.envs/development/frontendからはVITE_API_BASE_URLは削除する
         VITE_API_BASE_URL: http://localhost:8000
+    env_file:
+      - ./.envs/development/frontend
+    working_dir: /app
+    command: npm run build
+    volumes:
+      - ./frontend:/app
+      - node_modules:/app/node_modules
+    user: "${UID:-1000}:${GID:-1000}"
+    container_name: djangoblog_development_buildonly_frontend
+    profiles:
+      - buildonly  # docker composeコマンドで起動時は --profile=buildonlyをいれた時にだけ起動 = 単にupするとこのコンテナは起動しない
+  # front_nginx & backend_gunicorn & postgresサービスは、↑でfrontendのビルドができてから、docker compose -f development.yml upで起動する。
+  front_nginx:  
+    image: nginx:latest
+    container_name: djangoblog_development_front_nginx
     ports:
       - "8080:80"
     volumes:
-      # - ./frontend:/app  # ホストの ./frontend をコンテナの /app にマウント（コード変更が即反映される）<- いらない。vite開発サーバーはdevelopmentでは使わないから
-      - ./front_nginx:/front_nginx
-      - node_modules:/app/node_modules  # node_modules はボリュームで分離（ホストと衝突を避ける）ただしこのディレクトリはroot所有者になる。
-    env_file:
-      - ./.envs/development/frontend
+      - ./frontend/dist:/usr/share/nginx/html:ro
+      - ./front_nginx/nginx_confs/development/nginx.conf:/etc/nginx/nginx.conf
+    restart: always
   playwright-mock:
     build:
       context: .
@@ -37,8 +54,6 @@ services:
     container_name: djangoblog_development_backend_gunicorn
     restart: always
     user: "${UID:-1000}:${GID:-1000}"
-    # depends_on:
-    #   - postgres
     depends_on:
       postgres:
         condition: service_healthy
@@ -78,9 +93,9 @@ services:
 volumes:
   db_data:
   node_modules:  # Vueプロジェクトの依存ファイルを保持するボリューム
-  # frontend_build:  # フロントエンドのビルド結果を格納するボリューム
 
 #-------
 #このdocker-compose.ymlを使う場合、フロントエンドのビルドのためのコマンドと、配信のためのコマンドを叩く必要がある。
-# ビルド : docker-compose -f development.yml run --rm frontend-builder
-# 配信   : docker-compose -f development.yml up nginx
+# ビルド : docker compose -f development.yml run --rm frontend
+# 配信   : docker compose -f development.yml up
+# バックエンドのマイグレーション & スーパーユーザー作成 & 初期データ作成 : sh scripts/development/setup-scripts.sh

--- a/development.yml
+++ b/development.yml
@@ -10,6 +10,19 @@ services:
       # - ./frontend:/app  # ホストの ./frontend をコンテナの /app にマウント（コード変更が即反映される）<- いらない。vite開発サーバーはdevelopmentでは使わないから
       - ./front_nginx:/front_nginx
       - node_modules:/app/node_modules  # node_modules はボリュームで分離（ホストと衝突を避ける）ただしこのディレクトリはroot所有者になる。
+  playwright-mock:
+    build:
+      context: .
+      dockerfile: ./playwright-mock/dockerfile/local/Dockerfile
+    profiles:
+      - e2e-mock
+    depends_on:
+      - front_nginx
+    working_dir: /app
+    env_file:
+      - ./.envs/development/frontend
+    volumes:
+      - ./playwright-mock:/app  # ← playwright-mock の中の mocked_tests をマウント
 volumes:
   db_data:
   node_modules:  # Vueプロジェクトの依存ファイルを保持するボリューム

--- a/frontend/dockerfile/development/Dockerfile
+++ b/frontend/dockerfile/development/Dockerfile
@@ -4,6 +4,11 @@ FROM node:22.14.0-bullseye-slim AS builder
 # Docker イメージをビルドする時の、コンテナ内作業ディレクトリを /app に設定
 # このディレクトリを基準にして、この後のRUNやCOPYが実行される。
 WORKDIR /app
+# build-time ARG の定義
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+# ENV VITE_API_BASE_URL=abc
+
 # npmパッケージのインストール開始
 COPY frontend/package*.json ./
 RUN npm install

--- a/frontend/dockerfile/development/Dockerfile
+++ b/frontend/dockerfile/development/Dockerfile
@@ -1,28 +1,30 @@
 # マルチステージDockerfile(node.jsでビルド してから nginxでビルド結果を配信)
 # slim系のnodeから構築することを定義(22は比較的新しくてLTSなので採用)
-FROM node:22.14.0-bullseye-slim AS builder
+FROM node:22.14.0-bullseye-slim
 # Docker イメージをビルドする時の、コンテナ内作業ディレクトリを /app に設定
 # このディレクトリを基準にして、この後のRUNやCOPYが実行される。
 WORKDIR /app
-# build-time ARG の定義
+# # build-time ARG の定義
 ARG VITE_API_BASE_URL
-ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
-# ENV VITE_API_BASE_URL=abc
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+# # ENV VITE_API_BASE_URL=abc
 
 # npmパッケージのインストール開始
-COPY frontend/package*.json ./
-RUN npm install
+# COPY frontend/package*.json ./
+COPY package*.json ./
+# RUN npm install
+RUN npm install && chown -R 1000:1000 /app/node_modules
 # vue.jsのビルド開始
-COPY frontend/ ./
-RUN npm run build
-#---ここまでが、node.jsイメージでのステージ(ビルド用) --　ここからはnginxでの動作---
-# nginxでの配信用ステージ（最終イメージ）
-FROM nginx:latest
-# マルチステージビルドの1つめ(=AS builderとしたFROM部分)で作成されたコンテナの/app/distディレクトリ内のものをnginxコンテナの配信ディレクトリへコピー
-COPY --from=builder /app/dist /usr/share/nginx/html
+# COPY frontend/ ./
+# RUN npm run build
+# #---ここまでが、node.jsイメージでのステージ(ビルド用) --　ここからはnginxでの動作---
+# # nginxでの配信用ステージ（最終イメージ）
+# FROM nginx:latest
+# # マルチステージビルドの1つめ(=AS builderとしたFROM部分)で作成されたコンテナの/app/distディレクトリ内のものをnginxコンテナの配信ディレクトリへコピー
+# COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Nginx 設定カスタマイズが必要なら:
-COPY front_nginx/nginx_confs/development/nginx.conf /etc/nginx/nginx.conf
+# # Nginx 設定カスタマイズが必要なら:
+# COPY front_nginx/nginx_confs/development/nginx.conf /etc/nginx/nginx.conf
 
-# このDockerfileとdevelopment.ymlを使う場合、docker-compose -f development.yml up --buildでいい
-# 実行後は、http://localhost:8080でビルド後の結果を配信できる
+# # このDockerfileとdevelopment.ymlを使う場合、docker-compose -f development.yml up --buildでいい
+# # 実行後は、http://localhost:8080でビルド後の結果を配信できる

--- a/frontend/dockerfile/development/Dockerfile
+++ b/frontend/dockerfile/development/Dockerfile
@@ -13,6 +13,7 @@ RUN npm run build
 #---ここまでが、node.jsイメージでのステージ(ビルド用) --　ここからはnginxでの動作---
 # nginxでの配信用ステージ（最終イメージ）
 FROM nginx:latest
+# マルチステージビルドの1つめ(=AS builderとしたFROM部分)で作成されたコンテナの/app/distディレクトリ内のものをnginxコンテナの配信ディレクトリへコピー
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Nginx 設定カスタマイズが必要なら:

--- a/frontend/dockerfile/development/Dockerfile
+++ b/frontend/dockerfile/development/Dockerfile
@@ -4,27 +4,14 @@ FROM node:22.14.0-bullseye-slim
 # Docker イメージをビルドする時の、コンテナ内作業ディレクトリを /app に設定
 # このディレクトリを基準にして、この後のRUNやCOPYが実行される。
 WORKDIR /app
-# # build-time ARG の定義
+# build用ARG の定義
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
-# # ENV VITE_API_BASE_URL=abc
 
 # npmパッケージのインストール開始
-# COPY frontend/package*.json ./
 COPY package*.json ./
-# RUN npm install
 RUN npm install && chown -R 1000:1000 /app/node_modules
-# vue.jsのビルド開始
-# COPY frontend/ ./
-# RUN npm run build
-# #---ここまでが、node.jsイメージでのステージ(ビルド用) --　ここからはnginxでの動作---
-# # nginxでの配信用ステージ（最終イメージ）
-# FROM nginx:latest
-# # マルチステージビルドの1つめ(=AS builderとしたFROM部分)で作成されたコンテナの/app/distディレクトリ内のものをnginxコンテナの配信ディレクトリへコピー
-# COPY --from=builder /app/dist /usr/share/nginx/html
-
-# # Nginx 設定カスタマイズが必要なら:
-# COPY front_nginx/nginx_confs/development/nginx.conf /etc/nginx/nginx.conf
+# vue.jsのビルドは-f development.yml run --rm frontendで開始
 
 # # このDockerfileとdevelopment.ymlを使う場合、docker-compose -f development.yml up --buildでいい
 # # 実行後は、http://localhost:8080でビルド後の結果を配信できる

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "yup": "^1.6.1"
       },
       "devDependencies": {
+        "@types/node": "^22.15.3",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/tsconfig": "^0.7.0",
         "typescript": "~5.7.2",
@@ -1180,6 +1181,16 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
+      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.3",
@@ -3324,6 +3335,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/vee-validate": {
       "version": "4.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "yup": "^1.6.1"
   },
   "devDependencies": {
+    "@types/node": "^22.15.3",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/tsconfig": "^0.7.0",
     "typescript": "~5.7.2",

--- a/frontend/src/pages/BlogCreate.vue
+++ b/frontend/src/pages/BlogCreate.vue
@@ -69,7 +69,7 @@ const { handleSubmit, errors :form_errors } = useForm({
 // 各フィールドを useField で接続
 // {value: title}のtitleは、v-modelで使用できるようになる。useField('title')の方はschemaｍのyup.objectに入れたオブジェクトのことを指す
 const { value: title} = useField('title')
-const { value: contents_text} = useField('contents_text')
+const { value: contents_text} = useField<string>('contents_text')
 // useFieldで定義しているので、v-modelで双方バインディングする変数は作成しなくていい。
 // const title = ref("")
 // const contentsText = ref("")

--- a/frontend/src/pages/BlogDetail.vue
+++ b/frontend/src/pages/BlogDetail.vue
@@ -34,7 +34,14 @@
 import { ref, onMounted } from "vue";
 import { useRoute,useRouter } from "vue-router";
 
-const blog = ref(null);
+// interface
+interface Blog {
+  id: number
+  title: string
+  contents_text: string
+  created: string  // 日付はISO文字列として扱う場合は string
+}
+const blog = ref<Blog>();
 const route = useRoute();
 const router = useRouter()
 

--- a/frontend/src/pages/BlogList.vue
+++ b/frontend/src/pages/BlogList.vue
@@ -74,19 +74,39 @@
 <script setup lang="ts">
   import { ref, onMounted, watch } from "vue";
   import moment from "moment"
-   
+  
+  // interface
+  interface Blog {
+    id: number
+    title: string
+    contents_text: string
+    created: string  // 日付はISO文字列として扱う場合は string
+  }
+  interface BlogListResponse {
+    results: Blog[]
+    num_of_items: number
+  }
+
   const baseURL = import.meta.env.VITE_API_BASE_URL;
-  const blogs = ref([]);
-  const searchword = ref("");
-  const currentPage = ref(1);
-  const pageSize = ref(10);
-  const totalPages = ref(1);
+  // const blogs = ref([]);
+  const blogs = ref<Blog[]>([]);
+  // const searchword = ref("");
+  // const currentPage = ref(1);
+  // const pageSize = ref(10);
+  // const totalPages = ref(1);
+
+  const searchword = ref<string>('')
+  const totalPages = ref<number>(1)
+  const currentPage = ref<number>(1)
+  const pageSize = ref<number>(10)
+
 
   // methods  
   const getBlogLists = async ()=>{
     try {
       const response = await fetch(`${baseURL}/api/v1/blogs/?page=${currentPage.value}&size=${pageSize.value}`);
-      const responseBody = await response.json();
+      // const responseBody = await response.json();
+      const responseBody: BlogListResponse = await response.json()
       blogs.value = responseBody["results"];
       totalPages.value = Math.ceil(responseBody["num_of_items"] /pageSize.value);
     } catch (error) {

--- a/frontend/src/pages/BlogList.vue
+++ b/frontend/src/pages/BlogList.vue
@@ -105,6 +105,9 @@
   const getBlogLists = async ()=>{
     try {
       const response = await fetch(`${baseURL}/api/v1/blogs/?page=${currentPage.value}&size=${pageSize.value}`);
+      console.log("---baseURL=",baseURL)
+      console.log("---response=",response)
+      // console.log("---await response.json()=",await response.json())
       // const responseBody = await response.json();
       const responseBody: BlogListResponse = await response.json()
       blogs.value = responseBody["results"];

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -8,7 +8,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    /* パスエイリアス追加 */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,12 +15,51 @@
 //   },
 // })
 
+//-------------
+
+// import { defineConfig } from 'vite'
+// import vue from '@vitejs/plugin-vue'
+// import tailwindcss from '@tailwindcss/vite'
+// import path from 'path'
+// export default defineConfig({
+//   base: "/",  // ルート配信
+//   build: {
+//     outDir: "dist",
+//   },
+//   plugins: [
+//     vue(),
+//     tailwindcss(),
+//   ],
+//   //importする時のパスの入力に、@で示すルートディレクトリの位置を指定
+//   resolve: {
+//     alias: {
+//       '@': path.resolve(__dirname, './src') // @でsrcディレクトリを指すように設定
+//     }
+//   },
+//   server: {
+//     host: "0.0.0.0",  // コンテナ外からアクセス可能にする
+//     port: 5173,       // デフォルトポート
+//     watch: {
+//       usePolling: true, // WSL2 や Docker でホットリロードを確実に機能させる
+//     },
+//     allowedHosts: ['frontend'], // ← Playwright などからのアクセス用 page.content()をplaywrightのテストケースにいれたらエラーだったので。
+//   },
+//   test: {
+//     environment: 'jsdom',     // ← 仮想ブラウザ環境を指定
+//     globals: true,             // it/test/expect をグローバルに使えるように
+//     include: ['tests/**/*.test.ts'], // 任意：テスト対象ファイルのパターン
+//   },
+// })
+
+
+//----------------
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
-import path from 'path'
+import { fileURLToPath, URL } from 'node:url'
+
 export default defineConfig({
-  base: "/",  // ルート配信
+  base: "/",
   build: {
     outDir: "dist",
   },
@@ -28,23 +67,17 @@ export default defineConfig({
     vue(),
     tailwindcss(),
   ],
-  //importする時のパスの入力に、@で示すルートディレクトリの位置を指定
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src') // @でsrcディレクトリを指すように設定
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     }
   },
   server: {
-    host: "0.0.0.0",  // コンテナ外からアクセス可能にする
-    port: 5173,       // デフォルトポート
+    host: "0.0.0.0",
+    port: 5173,
     watch: {
-      usePolling: true, // WSL2 や Docker でホットリロードを確実に機能させる
+      usePolling: true,
     },
-    allowedHosts: ['frontend'], // ← Playwright などからのアクセス用 page.content()をplaywrightのテストケースにいれたらエラーだったので。
-  },
-  test: {
-    environment: 'jsdom',     // ← 仮想ブラウザ環境を指定
-    globals: true,             // it/test/expect をグローバルに使えるように
-    include: ['tests/**/*.test.ts'], // 任意：テスト対象ファイルのパターン
-  },
+    allowedHosts: ['frontend'],
+  }
 })

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['tests/**/*.test.ts']
+  }
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config'
-
+import viteConfig from './vite.config'
 export default defineConfig({
+  ...viteConfig,
   test: {
+    ...viteConfig.test,
     environment: 'jsdom',
     globals: true,
     include: ['tests/**/*.test.ts']

--- a/local.yml
+++ b/local.yml
@@ -76,6 +76,8 @@ services:
       - frontend
     working_dir: /app
     user: "${UID:-1000}:${GID:-1000}"
+    env_file:
+      - ./.envs/local/frontend
     volumes:
       - ./playwright-mock:/app  # ← テストケースファイルはこの中のe2e_testsディレクトリだが、test_resultsもここに作成される
     # entrypoint: [ "tail", "-f", "/dev/null" ]  # デバッグ用。任意で変更可。

--- a/local.yml
+++ b/local.yml
@@ -68,7 +68,7 @@ services:
       context: .
       dockerfile: ./playwright-mock/dockerfile/local/Dockerfile
     image: djangoblog_local_playwright_mock_img
-    container_name: djangoblog_local_playwright_mock
+    container_name: djangoblog_local_playwright-mock
     profiles: # 単にdocker-compose upをしただけでは、このplaywrightサービスは動かないようにする --profile e2e-mockが指定されたら動かせる
       - e2e-mock
     depends_on:

--- a/playwright-mock/dockerfile/local/Dockerfile
+++ b/playwright-mock/dockerfile/local/Dockerfile
@@ -7,7 +7,8 @@ COPY ./playwright-mock/dockerfile/local/requirements.txt /app/requirements.txt
 RUN pip install --upgrade pip && pip install -r requirements.txt
 
 # Playwrightのブラウザをインストール（必要に応じて）
-RUN playwright install
+# chromiumだけ指定してるが、しなかったらChromiumと、Chromium HeadlessとFirefoxとWebkitのダウンロード = 時間かかりすぎる
+RUN playwright install chromium
 
 # ----
 # 【このplaywrightコンテナを使ったテストを実施する方法】

--- a/playwright-mock/mocked_tests/blog/test_list.py
+++ b/playwright-mock/mocked_tests/blog/test_list.py
@@ -1,9 +1,12 @@
 # # playwright/e2etests/test_blog_list.py
-import pytest
+import pytest, json, os
 from playwright.sync_api import Page, Route, Request, expect
 def test_pagetitle(page):
     # playwrightコンテナから、フロントエンドへアクセスする場合、localhost:5173ではなく、docker-composeのサービス名でのアクセスが必要
-    page.goto("http://frontend:5173/blogs/")
+    base_url = os.environ.get("BASE_URL")
+    # page.goto("http://frontend:5173/blogs/")
+    # page.goto('http://front_nginx/blogs/')
+    page.goto(f"{base_url}/blogs")
     # page.content() # <- デバッグ用 playwrightが見ているpageのDOMを全部出力する
     # page.wait_for_selector("text=ブログ一覧")  # ← これで特定の要素が表示されるまで待つことができる(↓のexpectで待つことができるから不要だが)
     
@@ -41,8 +44,12 @@ def test_blog_list_with_mocked_api(page: Page, mocked_blog_api_response):
 
     # モックを有効化
     page.route("**/api/v1/blogs/**", handle_route)
+    base_url = os.environ.get("BASE_URL")
 
-    page.goto("http://frontend:5173/blogs/")
+    
+    # page.goto("http://frontend:5173/blogs/")
+    # page.goto('http://front_nginx/blogs/')
+    page.goto(f"{base_url}/blogs")
     expect(page.get_by_test_id("bloglist-section-title")).to_have_text("ブログ一覧")
     # expect(page.locator('[data-testid="bloglist-blog-item"]')).to_have_count(4)
     expect(page.get_by_test_id("bloglist-blog-item")).to_have_count(4)
@@ -110,7 +117,10 @@ def test_pagination_next_page(page: Page, mocked_paginated_response2p):
 
     page.route("**/api/v1/blogs/**", handle_route)
 
-    page.goto("http://frontend:5173/blogs/")
+    base_url = os.environ.get("BASE_URL")
+    # page.goto("http://frontend:5173/blogs/")
+    # page.goto('http://front_nginx/blogs/')
+    page.goto(f"{base_url}/blogs")
     expect(page.get_by_test_id("bloglist-blog-item")).to_have_count(10)
     expect(page.get_by_test_id("bloglist-blog-title-1")).to_be_visible()
     expect(page.get_by_test_id("bloglist-blog-title-13")).not_to_be_visible()
@@ -183,7 +193,11 @@ def test_blogs_title_click_navigates_to_detail(page: Page, blog_list_response, b
     page.route("**/api/v1/blogs/**", handle_route_bloglist)
     page.route("**/api/v1/blogs/1/**", handle_route_blogretrieve1)
     # 一覧ページを開く
-    page.goto("http://frontend:5173/blogs/")
+    base_url = os.environ.get("BASE_URL")
+    # page.goto("http://frontend:5173/blogs/")
+    # page.goto('http://front_nginx/blogs/')
+    page.goto(f"{base_url}/blogs")
+
     expect(page.get_by_test_id("bloglist-blog-title-1")).to_have_text("モックタイトル1")
 
     # タイトルクリックで詳細へ遷移

--- a/scripts/development/setup-script.sh
+++ b/scripts/development/setup-script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# バックエンドのマイグレーション + スーパーユーザー作成 + サンプルデータ作成をするスクリプト
+# 実行する時は scriptsディレクトリがあるところ= djangoblogディレクトリで、sh setup-script.shで実行してください。
+docker compose -f development.yml run --rm backend_gunicorn python manage.py migrate  && docker compose -f development.yml run --rm backend_gunicorn python manage.py createsuperuser --no-input && docker compose -f development.yml run --rm backend_gunicorn python manage.py create_sample_data
+
+if [ $? -eq 0 ]; then
+    echo "正常に終了しました。"
+else
+    echo "スクリプトが失敗しました"
+fi


### PR DESCRIPTION
# このPRで実現したこと

development.ymlでフロント、バックエンドが起動時でき、各種テストが実施できるようになりました。(e2eテストについては、mockedの方でできるようにした。realの方はe2e.ymlなので別。)

## development.ymlからの起動方法

- 1.フロントエンドビルドがまず必要 : `docker compose -f development.yml run --rm frontend`
  - `local.yml`との大きな違いがここ。
    - `local.yml`のフロントエンドはviteの開発サーバーだったが、`development.yml`では、フロントエンドで`npm run build`を実施 → その成果物をnginxが静的ファイルとして配信する = `development.yml`で起動させるのはnginxコンテナであり、vite開発サーバーではない。
    - 以降の記述で行うmockedなe2eテスト(=`playwright-mock`でのテスト)ではこのnginxで配信されるフロントエンドを元にしたブラウザテストとなる。
    - フロントエンドのユニットテスト(vitest)についてはnginxに関係がないテストになるので`developtment.yml`からの環境で実施する意味はあまりない(実施はできるけど)。
- 2.開発環境の起動方法 : `docker compose -f development.yml up`
  - 上記の理由から、`frontend`サービスのコンテナはupでは起動しない。代わりに`frontend_nginx`が起動する
- 3.開発環境でのマイグレーション、スーパーユーザー作成、仮データ準備 : `sh scripts/development/setup-script.sh`

## development.ymlでのテストの方法

- 開発環境の`backend_gunicorn`サービス=バックエンドのテスト : `docker compose -f development.yml run --rm backend_gunicorn pytest api/tests`
  - devでGithubActionsでやるべき

```
roo_wsl@roo-TUF-A16-24:~/djangoblog$ docker compose -f development.yml run --rm backend_gunicorn pytest api/tests
[+] Running 1/1
 ! postgres Warning pull access denied for djangoblog_development_postgres_img, repository do...                   6.0s
Compose can now delegate builds to bake for better performance.
 To do so, set COMPOSE_BAKE=true.
[+] Building 4.2s (9/9) FINISHED                                                                         docker:default
 => [postgres internal] load build definition from Dockerfile                                                      0.0s
 => => transferring dockerfile: 243B                                                                               0.0s
 => [postgres internal] load metadata for docker.io/library/postgres:15                                            4.0s
 => [postgres internal] load .dockerignore                                                                         0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [postgres 1/3] FROM docker.io/library/postgres:15@sha256:8f6fbd24a12304d2adc332a2162ee9ff9d6044045a0b07f94d6e  0.0s
 => [postgres internal] load build context                                                                         0.0s
 => => transferring context: 33B                                                                                   0.0s
 => CACHED [postgres 2/3] COPY ./check-db.sh /usr/local/bin/check-db.sh                                            0.0s
 => CACHED [postgres 3/3] RUN chmod +x /usr/local/bin/check-db.sh                                                  0.0s
 => [postgres] exporting to image                                                                                  0.0s
 => => exporting layers                                                                                            0.0s
 => => writing image sha256:fce02d8c3298f45892915cf0d3c835d753a5b72b74140f55f26e81948aee0f3b                       0.0s
 => => naming to docker.io/library/djangoblog_development_postgres_img                                             0.0s
 => [postgres] resolving provenance for metadata file                                                              0.0s
WARN[0010] Found orphan containers ([djangoblog_local_backend]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
[+] Creating 2/2
 ✔ postgres                             Built                                                                      0.0s
 ✔ Container djangoblog_local_postgres  Recreated                                                                  0.5s
[+] Running 1/1
 ✔ Container djangoblog_development_postgres  Started                                                              0.3s
[+] Running 1/1
 ! backend_gunicorn Warning pull access denied for djangoblog_development_backend_img...                           7.3s
[+] Building 1.4s (10/10) FINISHED                                                                       docker:default
 => [backend_gunicorn internal] load build definition from Dockerfile                                              0.0s
 => => transferring dockerfile: 657B                                                                               0.0s
 => [backend_gunicorn internal] load metadata for docker.io/library/python:3.12-slim                               1.2s
 => [backend_gunicorn internal] load .dockerignore                                                                 0.0s
 => => transferring context: 53B                                                                                   0.0s
 => [backend_gunicorn 1/4] FROM docker.io/library/python:3.12-slim@sha256:bae1a061b657f403aaacb1069a7f67d91f7ef57  0.0s
 => [backend_gunicorn internal] load build context                                                                 0.0s
 => => transferring context: 904B                                                                                  0.0s
 => CACHED [backend_gunicorn 2/4] WORKDIR /app                                                                     0.0s
 => CACHED [backend_gunicorn 3/4] COPY ./backend/requirements/development.txt /app/requirements/development.txt    0.0s
 => CACHED [backend_gunicorn 4/4] RUN pip install --upgrade pip && pip install -r /app/requirements/development.t  0.0s
 => [backend_gunicorn] exporting to image                                                                          0.0s
 => => exporting layers                                                                                            0.0s
 => => writing image sha256:0d377f6ab0039be51b14f338e30e9a7b35b6f9bb627b25363273646020f5c731                       0.0s
 => => naming to docker.io/library/djangoblog_development_backend_img                                              0.0s
 => [backend_gunicorn] resolving provenance for metadata file                                                      0.0s
Test session starts (platform: linux, Python 3.12.10, pytest 8.3.5, pytest-sugar 1.0.0)
django: version: 5.1.7, settings: config.settings_fortest (from option)
rootdir: /app
configfile: pytest.ini
plugins: Faker-37.1.0, mock-3.14.0, xdist-3.6.1, sugar-1.0.0, django-4.10.0
collected 20 items

 api/tests/blogs/test_create.py ✓✓✓✓✓                                                                     25% ██▌
 api/tests/blogs/test_list.py ✓✓✓                                                                         40% ████
 api/tests/blogs/test_query.py ✓✓✓                                                                        55% █████▌
 api/tests/blogs/test_retrieve.py ✓✓                                                                      65% ██████▌
 api/tests/test_pagination.py ✓✓                                                                          75% ███████▌
 api/tests/test_smoke.py ✓✓                                                                               85% ████████▌
 api/tests/blogs/test_serializer.py ✓✓✓                                                                  100% ██████████

Results (0.50s):
      20 passed
```

- 開発環境でのmockedなe2eテスト : `docker compose -f development.yml --profile e2e-mock run --rm playwright-mock pytest mocked_tests`
  - devでGithubActionsでやるべき

```
roo_wsl@roo-TUF-A16-24:~/djangoblog$ docker compose -f development.yml --profile e2e-mock run --rm playwright-mock pytest mocked_tests
[+] Running 8/8
 ✔ front_nginx Pulled                                                                                             17.2s
   ✔ 254e724d7786 Already exists                                                                                   0.0s
   ✔ 913115292750 Pull complete                                                                                    9.1s
   ✔ 3e544d53ce49 Pull complete                                                                                    9.1s
   ✔ 4f21ed9ac0c0 Pull complete                                                                                    9.1s
   ✔ d38f2ef2d6f2 Pull complete                                                                                    9.2s
   ✔ 40a6e9f4e456 Pull complete                                                                                    9.2s
   ✔ d3dc5ec71e9d Pull complete                                                                                    9.2s
WARN[0017] Found orphan containers ([djangoblog_local_backend]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
[+] Creating 1/1
 ✔ Container djangoblog_development_front_nginx  Created                                                           0.2s
[+] Running 1/1
 ✔ Container djangoblog_development_front_nginx  Started                                                           0.2s
================================================= test session starts ==================================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /app
plugins: playwright-0.7.0, base-url-2.1.0
collected 11 items

mocked_tests/blog/test_create.py .......                                                                         [ 63%]
mocked_tests/blog/test_list.py ....                                                                              [100%]

================================================== 11 passed in 4.02s ==================================================
```

- 開発環境でのfrontのユニットテスト : `docker compose -f development.yml run --rm frontend npx vitest run tests`
  - GithubActionsでやってもいいが、localで手動実行でもいいかも

```docker compose -f development.yml run --rm frontend npx vitest run tests
WARN[0000] Found orphan containers ([djangoblog_local_backend]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.

 RUN  v3.1.1 /app

 ✓ tests/unit/AppSearchInput.test.ts (5 tests) 33ms
 ✓ tests/unit/AppTransitionPageButton.test.ts (1 test) 32ms
 ✓ tests/unit/BlogCreate.test.ts (1 test) 37ms

 Test Files  3 passed (3)
      Tests  7 passed (7)
   Start at  00:01:26
   Duration  1.16s (transform 257ms, setup 0ms, collect 628ms, tests 102ms, environment 1.67s, prepare 217ms)```

## 余談
- フロントエンドのビルドはfrontendコンテナ(=local.ymlではvite開発サーバーを使っていた)で行う。
  - この時、development.ymlにて`build.args.VITE_API_BASE_URL`の値を使う(=frontendサービスのビルド時に`npm run build`する)ので、`.envs/development/frontend`からは、`VITE_API_BASE_URL`はいらなくなった。
  - 一方、`BASE_URL`は、developmentでのmockedテストのため`.envs/development/frontend`に必要

## 今後実施すること
- GithubActionsでのCIは、このdevelopment.ymlをベースとしたやりかたにする
- traefikを導入し、docker-composeのサービス名を使用したリクエスト・レスポンスではなく、ドメイン名でリクエスト・レスポンスできるようにする